### PR TITLE
Make tests independants of private robots models

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ SET(${PROJECT_NAME}_TESTS
   #fullbody
   #interpolate
   #contact-gen
-  reachability
+  #reachability
   rbrrt
   projection
   kinodynamic

--- a/tests/test-kinodynamic.cc
+++ b/tests/test-kinodynamic.cc
@@ -106,23 +106,38 @@ bool checkPath(core::PathPtr_t path, double v,double dt = 0.01){
 
 BOOST_AUTO_TEST_SUITE( rbrrt_kinodynamic )
 
-BOOST_AUTO_TEST_CASE (load_abstract_model) {
+BOOST_AUTO_TEST_CASE (load_abstract_model_hyq) {
 
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadHyQAbsract();
     //for(size_t i = 0 ; i < rbprmDevice->data().mass.size() ; ++i)
     //  std::cout<<"mass : "<<i<<" = "<<rbprmDevice->data().mass[i]<<std::endl;
-    //BOOST_CHECK_CLOSE(rbprmDevice->mass(),90.27,1e-2); // FIXME : need to investigate and open an issue
+    //BOOST_CHECK_CLOSE(rbprmDevice->mass(),70.,1e-2); // FIXME : need to investigate and open an issue
     hpp::core::ProblemSolverPtr_t ps = hpp::core::ProblemSolver::create();
     ps->robot(rbprmDevice);
-    BOOST_CHECK_CLOSE(rbprmDevice->mass(),90.27,1e-2);
-    BOOST_CHECK_CLOSE(ps->robot()->mass(),90.27,1e-2);
+    BOOST_CHECK_CLOSE(rbprmDevice->mass(),50.26,1e-2);
+    BOOST_CHECK_CLOSE(ps->robot()->mass(),50.26,1e-2);
+    //for(size_t i = 0 ; i < rbprmDevice->data().mass.size() ; ++i)
+    //  std::cout<<"mass : "<<i<<" = "<<rbprmDevice->data().mass[i]<<std::endl;
+}
+
+
+BOOST_AUTO_TEST_CASE (load_abstract_model_simpleHumanoid) {
+
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
+    //for(size_t i = 0 ; i < rbprmDevice->data().mass.size() ; ++i)
+    //  std::cout<<"mass : "<<i<<" = "<<rbprmDevice->data().mass[i]<<std::endl;
+    //BOOST_CHECK_CLOSE(rbprmDevice->mass(),70.,1e-2); // FIXME : need to investigate and open an issue
+    hpp::core::ProblemSolverPtr_t ps = hpp::core::ProblemSolver::create();
+    ps->robot(rbprmDevice);
+    BOOST_CHECK_CLOSE(rbprmDevice->mass(),70.,1e-2);
+    BOOST_CHECK_CLOSE(ps->robot()->mass(),70.,1e-2);
     //for(size_t i = 0 ; i < rbprmDevice->data().mass.size() ; ++i)
     //  std::cout<<"mass : "<<i<<" = "<<rbprmDevice->data().mass[i]<<std::endl;
 }
 
 
 BOOST_AUTO_TEST_CASE (straight_line) {
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
     rbprmDevice->setDimensionExtraConfigSpace(6);
     BindShooter bShooter;
     std::vector<double> boundsSO3;
@@ -170,14 +185,14 @@ BOOST_AUTO_TEST_CASE (straight_line) {
 
     // define the planning problem :
     core::Configuration_t q_init(rbprmDevice->configSize());
-    q_init << 0, 0, 1.0, 0, 0, 0, 1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    q_init << 0, 0, 1.0, 0, 0, 0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
 
     core::Configuration_t q_goal = q_init;
     q_goal(0)=1.5;
 
     pSolver.initConfig(ConfigurationPtr_t(new core::Configuration_t(q_init)));
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
-    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),90.27,1e-2);
+    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),70.,1e-2);
     bool success = pSolver.prepareSolveStepByStep();
     BOOST_CHECK(success);
     pSolver.finishSolveStepByStep();
@@ -205,7 +220,7 @@ BOOST_AUTO_TEST_CASE (straight_line) {
 
 
 BOOST_AUTO_TEST_CASE (square_v0) {
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
     rbprmDevice->setDimensionExtraConfigSpace(6);
     BindShooter bShooter;
     std::vector<double> boundsSO3;
@@ -253,7 +268,7 @@ BOOST_AUTO_TEST_CASE (square_v0) {
 
     // define the planning problem :
     core::Configuration_t q_init(rbprmDevice->configSize());
-    q_init << 0, 0, 1.0, 0, 0, 0, 1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    q_init << 0, 0, 1.0, 0, 0, 0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
 
     core::Configuration_t q_goal = q_init;
     q_goal(0)=1.;
@@ -373,7 +388,7 @@ BOOST_AUTO_TEST_CASE (square_v0) {
 
 
 BOOST_AUTO_TEST_CASE (straight_velocity) {
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
     rbprmDevice->setDimensionExtraConfigSpace(6);
     BindShooter bShooter;
     std::vector<double> boundsSO3;
@@ -421,8 +436,8 @@ BOOST_AUTO_TEST_CASE (straight_velocity) {
 
     // define the planning problem :
     core::Configuration_t q_init(rbprmDevice->configSize());
-    q_init << 0, 0, 1.0, 0, 0, 0, 1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
-    q_init(9) = 0.5; // init velocity along x
+    q_init << 0, 0, 1.0, 0, 0, 0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    q_init(7) = 0.5; // init velocity along x
     core::Configuration_t q_goal = q_init;
     q_goal(0)=1.;
 
@@ -443,8 +458,8 @@ BOOST_AUTO_TEST_CASE (straight_velocity) {
 
     pSolver.resetGoalConfigs();
     q_goal(0) = 0.;
-    q_goal(9) = 0.1;
-    q_goal(10) = -0.2; // final velocity
+    q_goal(7) = 0.1;
+    q_goal(8) = -0.2; // final velocity
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
     success = pSolver.prepareSolveStepByStep();
     BOOST_CHECK(success);
@@ -460,7 +475,7 @@ BOOST_AUTO_TEST_CASE (straight_velocity) {
 
     pSolver.resetGoalConfigs();
     q_goal(0) = 1.;
-    q_goal(9) = -0.3;
+    q_goal(7) = -0.3;
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
     success = pSolver.prepareSolveStepByStep();
     BOOST_CHECK(success);
@@ -476,8 +491,8 @@ BOOST_AUTO_TEST_CASE (straight_velocity) {
 
     pSolver.resetGoalConfigs();
     q_goal(0) = -1.;
-    q_goal(9) = 0.;
-    q_goal(10) = 0.3;
+    q_goal(7) = 0.;
+    q_goal(8) = 0.3;
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
     success = pSolver.prepareSolveStepByStep();
     BOOST_CHECK(success);
@@ -497,7 +512,7 @@ BOOST_AUTO_TEST_CASE (straight_velocity) {
 
 
 BOOST_AUTO_TEST_CASE (straight_line_amax_mu05) {
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
     rbprmDevice->setDimensionExtraConfigSpace(6);
     BindShooter bShooter;
     std::vector<double> boundsSO3;
@@ -529,10 +544,6 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_mu05) {
     pSolver.problem()->setParameter(std::string("DynamicPlanner/sizeFootY"),core::Parameter(0.12));
     pSolver.problem()->setParameter(std::string("DynamicPlanner/friction"),core::Parameter(0.5));
     pSolver.problem()->setParameter(std::string("ConfigurationShooter/sampleExtraDOF"),core::Parameter(false));
-    vector3_t p_lLeg(0., 0.0848172440888579,-1.019272022956703);
-    vector3_t p_rLeg(0., -0.0848172440888579,-1.019272022956703);
-    rbprmDevice->setEffectorReference("talos_lleg_rom",p_lLeg);
-    rbprmDevice->setEffectorReference("talos_rleg_rom",p_rLeg);
 
     for(size_type i = 0 ; i < 2 ; ++i){
       rbprmDevice->extraConfigSpace().lower(i)=-vMax;
@@ -549,14 +560,14 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_mu05) {
 
     // define the planning problem :
     core::Configuration_t q_init(rbprmDevice->configSize());
-    q_init << 0, 0, 1.0, 0, 0, 0, 1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    q_init << 0, 0, 1.0, 0, 0, 0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
 
     core::Configuration_t q_goal = q_init;
     q_goal(0)=1.5;
 
     pSolver.initConfig(ConfigurationPtr_t(new core::Configuration_t(q_init)));
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
-    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),90.27,1e-2);
+    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),70.,1e-2);
     bool success = pSolver.prepareSolveStepByStep();
     BOOST_CHECK(success);
     pSolver.finishSolveStepByStep();
@@ -566,7 +577,7 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_mu05) {
 
 
 BOOST_AUTO_TEST_CASE (straight_line_amax_mu005) {
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
     rbprmDevice->setDimensionExtraConfigSpace(6);
     BindShooter bShooter;
     std::vector<double> boundsSO3;
@@ -598,10 +609,6 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_mu005) {
     pSolver.problem()->setParameter(std::string("DynamicPlanner/sizeFootY"),core::Parameter(0.12));
     pSolver.problem()->setParameter(std::string("DynamicPlanner/friction"),core::Parameter(0.05));
     pSolver.problem()->setParameter(std::string("ConfigurationShooter/sampleExtraDOF"),core::Parameter(false));
-    vector3_t p_lLeg(0., 0.0848172440888579,-1.019272022956703);
-    vector3_t p_rLeg(0., -0.0848172440888579,-1.019272022956703);
-    rbprmDevice->setEffectorReference("talos_lleg_rom",p_lLeg);
-    rbprmDevice->setEffectorReference("talos_rleg_rom",p_rLeg);
 
     for(size_type i = 0 ; i < 2 ; ++i){
       rbprmDevice->extraConfigSpace().lower(i)=-vMax;
@@ -618,14 +625,14 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_mu005) {
 
     // define the planning problem :
     core::Configuration_t q_init(rbprmDevice->configSize());
-    q_init << 0, 0, 1.0, 0, 0, 0, 1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    q_init << 0, 0, 1.0, 0, 0, 0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
 
     core::Configuration_t q_goal = q_init;
     q_goal(0)=1.5;
 
     pSolver.initConfig(ConfigurationPtr_t(new core::Configuration_t(q_init)));
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
-    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),90.27,1e-2);
+    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),70.,1e-2);
     bool success = pSolver.prepareSolveStepByStep();
     BOOST_CHECK(success);
     pSolver.finishSolveStepByStep();
@@ -634,7 +641,7 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_mu005) {
 }
 
 BOOST_AUTO_TEST_CASE (straight_line_amax_mu001) {
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
     rbprmDevice->setDimensionExtraConfigSpace(6);
     BindShooter bShooter;
     std::vector<double> boundsSO3;
@@ -666,10 +673,6 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_mu001) {
     pSolver.problem()->setParameter(std::string("DynamicPlanner/sizeFootY"),core::Parameter(0.12));
     pSolver.problem()->setParameter(std::string("DynamicPlanner/friction"),core::Parameter(0.01));
     pSolver.problem()->setParameter(std::string("ConfigurationShooter/sampleExtraDOF"),core::Parameter(false));
-    vector3_t p_lLeg(0., 0.0848172440888579,-1.019272022956703);
-    vector3_t p_rLeg(0., -0.0848172440888579,-1.019272022956703);
-    rbprmDevice->setEffectorReference("talos_lleg_rom",p_lLeg);
-    rbprmDevice->setEffectorReference("talos_rleg_rom",p_rLeg);
 
     for(size_type i = 0 ; i < 2 ; ++i){
       rbprmDevice->extraConfigSpace().lower(i)=-vMax;
@@ -686,23 +689,23 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_mu001) {
 
     // define the planning problem :
     core::Configuration_t q_init(rbprmDevice->configSize());
-    q_init << 0, 0, 1.0, 0, 0, 0, 1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    q_init << 0, 0, 1.0, 0, 0, 0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
 
     core::Configuration_t q_goal = q_init;
     q_goal(0)=1.5;
 
     pSolver.initConfig(ConfigurationPtr_t(new core::Configuration_t(q_init)));
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
-    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),90.27,1e-2);
+    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),70.,1e-2);
     bool success = pSolver.prepareSolveStepByStep();
     BOOST_CHECK(success);
     pSolver.finishSolveStepByStep();
     BOOST_CHECK_EQUAL(pSolver.paths().size(),1);
-    BOOST_CHECK_CLOSE(pSolver.paths().back()->length(),8.253186224036595,1e-6);
+    BOOST_CHECK_CLOSE(pSolver.paths().back()->length(),8.2531857104894222,1e-6);
 }
 
 BOOST_AUTO_TEST_CASE (straight_line_amax_mu5) {
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
     rbprmDevice->setDimensionExtraConfigSpace(6);
     BindShooter bShooter;
     std::vector<double> boundsSO3;
@@ -734,10 +737,6 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_mu5) {
     pSolver.problem()->setParameter(std::string("DynamicPlanner/sizeFootY"),core::Parameter(0.12));
     pSolver.problem()->setParameter(std::string("DynamicPlanner/friction"),core::Parameter(5.));
     pSolver.problem()->setParameter(std::string("ConfigurationShooter/sampleExtraDOF"),core::Parameter(false));
-    vector3_t p_lLeg(0., 0.0848172440888579,-1.019272022956703);
-    vector3_t p_rLeg(0., -0.0848172440888579,-1.019272022956703);
-    rbprmDevice->setEffectorReference("talos_lleg_rom",p_lLeg);
-    rbprmDevice->setEffectorReference("talos_rleg_rom",p_rLeg);
 
     for(size_type i = 0 ; i < 2 ; ++i){
       rbprmDevice->extraConfigSpace().lower(i)=-vMax;
@@ -754,23 +753,23 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_mu5) {
 
     // define the planning problem :
     core::Configuration_t q_init(rbprmDevice->configSize());
-    q_init << 0, 0, 1.0, 0, 0, 0, 1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    q_init << 0, 0, 1.0, 0, 0, 0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
 
     core::Configuration_t q_goal = q_init;
     q_goal(0)=1.5;
 
     pSolver.initConfig(ConfigurationPtr_t(new core::Configuration_t(q_init)));
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
-    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),90.27,1e-2);
+    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),70.,1e-2);
     bool success = pSolver.prepareSolveStepByStep();
     BOOST_CHECK(success);
     pSolver.finishSolveStepByStep();
     BOOST_CHECK_EQUAL(pSolver.paths().size(),1);
-    BOOST_CHECK_CLOSE(pSolver.paths().back()->length(),2.5298683485627125,1e-6);
+    BOOST_CHECK_CLOSE(pSolver.paths().back()->length(),2.5298682886765311,1e-6);
 }
 
 BOOST_AUTO_TEST_CASE (straight_line_amax_feetChange) {
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
     rbprmDevice->setDimensionExtraConfigSpace(6);
     BindShooter bShooter;
     std::vector<double> boundsSO3;
@@ -802,10 +801,6 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_feetChange) {
     pSolver.problem()->setParameter(std::string("DynamicPlanner/sizeFootY"),core::Parameter(0.05));
     pSolver.problem()->setParameter(std::string("DynamicPlanner/friction"),core::Parameter(0.5));
     pSolver.problem()->setParameter(std::string("ConfigurationShooter/sampleExtraDOF"),core::Parameter(false));
-    vector3_t p_lLeg(0., 0.0848172440888579,-1.019272022956703);
-    vector3_t p_rLeg(0., -0.0848172440888579,-1.019272022956703);
-    rbprmDevice->setEffectorReference("talos_lleg_rom",p_lLeg);
-    rbprmDevice->setEffectorReference("talos_rleg_rom",p_rLeg);
 
     for(size_type i = 0 ; i < 2 ; ++i){
       rbprmDevice->extraConfigSpace().lower(i)=-vMax;
@@ -822,14 +817,14 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_feetChange) {
 
     // define the planning problem :
     core::Configuration_t q_init(rbprmDevice->configSize());
-    q_init << 0, 0, 1.0, 0, 0, 0, 1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
+    q_init << 0, 0, 1.0, 0, 0, 0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0;
 
     core::Configuration_t q_goal = q_init;
     q_goal(0)=1.5;
 
     pSolver.initConfig(ConfigurationPtr_t(new core::Configuration_t(q_init)));
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
-    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),90.27,1e-2);
+    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),70.,1e-2);
     bool success = pSolver.prepareSolveStepByStep();
     BOOST_CHECK(success);
     pSolver.finishSolveStepByStep();
@@ -841,7 +836,7 @@ BOOST_AUTO_TEST_CASE (straight_line_amax_feetChange) {
 BOOST_AUTO_TEST_CASE (nav_bauzil) {
     std::cout<<"start nav_bauzil test case, this may take a couple of minutes ..."<<std::endl;
   // this test case may take up to a minute to execute. Usually after ~5 minutes it should be considered as a failure.
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
     rbprmDevice->setDimensionExtraConfigSpace(6);
     BindShooter bShooter;
     std::vector<double> boundsSO3;
@@ -874,10 +869,6 @@ BOOST_AUTO_TEST_CASE (nav_bauzil) {
     pSolver.problem()->setParameter(std::string("DynamicPlanner/friction"),core::Parameter(0.5));
     pSolver.problem()->setParameter(std::string("ConfigurationShooter/sampleExtraDOF"),core::Parameter(false));
     pSolver.problem()->setParameter(std::string("PathOptimization/RandomShortcut/NumberOfLoops"),core::Parameter((core::size_type)50));
-    vector3_t p_lLeg(0., 0.0848172440888579,-1.019272022956703);
-    vector3_t p_rLeg(0., -0.0848172440888579,-1.019272022956703);
-    rbprmDevice->setEffectorReference("talos_lleg_rom",p_lLeg);
-    rbprmDevice->setEffectorReference("talos_rleg_rom",p_rLeg);
 
 
     for(size_type i = 0 ; i < 2 ; ++i){
@@ -895,13 +886,13 @@ BOOST_AUTO_TEST_CASE (nav_bauzil) {
 
     // define the planning problem :
     core::Configuration_t q_init(rbprmDevice->configSize());
-    q_init << -0.9, 1.5, 0.98, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.07, 0, 0, 0.0, 0.0, 0.0;
+    q_init << -0.9, 1.5, 1., 0.0, 0.0, 0.0, 1.0, 0.07, 0, 0, 0.0, 0.0, 0.0;
     core::Configuration_t q_goal(rbprmDevice->configSize());
-    q_goal << 2, 2.6, 0.98, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.1, 0, 0, 0.0, 0.0, 0.0;
+    q_goal << 2, 2.6, 1., 0.0, 0.0, 0.0, 1.0, 0.1, 0, 0, 0.0, 0.0, 0.0;
 
     pSolver.initConfig(ConfigurationPtr_t(new core::Configuration_t(q_init)));
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
-    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),90.27,1e-2);
+    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),70.,1e-2);
 
     pSolver.solve();
     BOOST_CHECK_EQUAL(pSolver.paths().size(),2);
@@ -923,7 +914,7 @@ BOOST_AUTO_TEST_CASE (nav_bauzil) {
 BOOST_AUTO_TEST_CASE (nav_bauzil_oriented) {
     std::cout<<"start nav_bauzil_oriented test case, this may take a couple of minutes ..."<<std::endl;
   // this test case may take up to a minute to execute. Usually after ~5 minutes it should be considered as a failure.
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
     rbprmDevice->setDimensionExtraConfigSpace(6);
     BindShooter bShooter;
     std::vector<double> boundsSO3;
@@ -957,10 +948,6 @@ BOOST_AUTO_TEST_CASE (nav_bauzil_oriented) {
     pSolver.problem()->setParameter(std::string("DynamicPlanner/friction"),core::Parameter(0.5));
     pSolver.problem()->setParameter(std::string("ConfigurationShooter/sampleExtraDOF"),core::Parameter(false));
     pSolver.problem()->setParameter(std::string("PathOptimization/RandomShortcut/NumberOfLoops"),core::Parameter((core::size_type)50));
-    vector3_t p_lLeg(0., 0.0848172440888579,-1.019272022956703);
-    vector3_t p_rLeg(0., -0.0848172440888579,-1.019272022956703);
-    rbprmDevice->setEffectorReference("talos_lleg_rom",p_lLeg);
-    rbprmDevice->setEffectorReference("talos_rleg_rom",p_rLeg);
 
 
     for(size_type i = 0 ; i < 2 ; ++i){
@@ -978,13 +965,13 @@ BOOST_AUTO_TEST_CASE (nav_bauzil_oriented) {
 
     // define the planning problem :
     core::Configuration_t q_init(rbprmDevice->configSize());
-    q_init << -0.9, 1.5, 0.98, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.07, 0, 0, 0.0, 0.0, 0.0;
+    q_init << -0.9, 1.5, 1., 0.0, 0.0, 0.0, 1.0, 0.07, 0, 0, 0.0, 0.0, 0.0;
     core::Configuration_t q_goal(rbprmDevice->configSize());
-    q_goal << 2, 2.6, 0.98, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.1, 0, 0, 0.0, 0.0, 0.0;
+    q_goal << 2, 2.6, 1., 0.0, 0.0, 0.0, 1.0, 0.1, 0, 0, 0.0, 0.0, 0.0;
 
     pSolver.initConfig(ConfigurationPtr_t(new core::Configuration_t(q_init)));
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
-    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),90.27,1e-2);
+    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),70.,1e-2);
 
     pSolver.solve();
     BOOST_CHECK_EQUAL(pSolver.paths().size(),2);
@@ -1006,7 +993,7 @@ BOOST_AUTO_TEST_CASE (nav_bauzil_oriented) {
 BOOST_AUTO_TEST_CASE (nav_bauzil_oriented_kino) {
     std::cout<<"start nav_bauzil_oriented_kino test case, this may take a couple of minutes ..."<<std::endl;
   // this test case may take up to a minute to execute. Usually after ~5 minutes it should be considered as a failure.
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
     rbprmDevice->setDimensionExtraConfigSpace(6);
     BindShooter bShooter;
     std::vector<double> boundsSO3;
@@ -1040,10 +1027,6 @@ BOOST_AUTO_TEST_CASE (nav_bauzil_oriented_kino) {
     pSolver.problem()->setParameter(std::string("DynamicPlanner/friction"),core::Parameter(0.5));
     pSolver.problem()->setParameter(std::string("ConfigurationShooter/sampleExtraDOF"),core::Parameter(true));
     pSolver.problem()->setParameter(std::string("PathOptimization/RandomShortcut/NumberOfLoops"),core::Parameter((core::size_type)50));
-    vector3_t p_lLeg(0., 0.0848172440888579,-1.019272022956703);
-    vector3_t p_rLeg(0., -0.0848172440888579,-1.019272022956703);
-    rbprmDevice->setEffectorReference("talos_lleg_rom",p_lLeg);
-    rbprmDevice->setEffectorReference("talos_rleg_rom",p_rLeg);
 
 
     for(size_type i = 0 ; i < 2 ; ++i){
@@ -1061,13 +1044,13 @@ BOOST_AUTO_TEST_CASE (nav_bauzil_oriented_kino) {
 
     // define the planning problem :
     core::Configuration_t q_init(rbprmDevice->configSize());
-    q_init << -0.9, 1.5, 0.98, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.07, 0, 0, 0.0, 0.0, 0.0;
+    q_init << -0.9, 1.5, 1., 0.0, 0.0, 0.0, 1.0, 0.07, 0, 0, 0.0, 0.0, 0.0;
     core::Configuration_t q_goal(rbprmDevice->configSize());
-    q_goal << 2, 2.6, 0.98, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.1, 0, 0, 0.0, 0.0, 0.0;
+    q_goal << 2, 2.6, 1., 0.0, 0.0, 0.0, 1.0, 0.1, 0, 0, 0.0, 0.0, 0.0;
 
     pSolver.initConfig(ConfigurationPtr_t(new core::Configuration_t(q_init)));
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
-    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),90.27,1e-2);
+    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),70.,1e-2);
 
     pSolver.solve();
     BOOST_CHECK_EQUAL(pSolver.paths().size(),2);
@@ -1090,7 +1073,7 @@ BOOST_AUTO_TEST_CASE (nav_bauzil_oriented_kino) {
 BOOST_AUTO_TEST_CASE (nav_bauzil_hard) {
     std::cout<<"start nav_bauzil_hard test case, this may take several minutes ..."<<std::endl;
   // this test case may take up to 5 minute to execute. Usually after ~10 minutes it should be considered as a failure.
-    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadTalosLEGAbsract();
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadsimpleHumanoidAbsract();
     rbprmDevice->rootJoint()->lowerBound(0, -2.3);
     rbprmDevice->rootJoint()->lowerBound(1, -1.5);
     rbprmDevice->rootJoint()->lowerBound(2, 0.98);
@@ -1130,10 +1113,6 @@ BOOST_AUTO_TEST_CASE (nav_bauzil_hard) {
     pSolver.problem()->setParameter(std::string("DynamicPlanner/friction"),core::Parameter(0.5));
     pSolver.problem()->setParameter(std::string("ConfigurationShooter/sampleExtraDOF"),core::Parameter(false));
     pSolver.problem()->setParameter(std::string("PathOptimization/RandomShortcut/NumberOfLoops"),core::Parameter((core::size_type)10));
-    vector3_t p_lLeg(0., 0.0848172440888579,-1.019272022956703);
-    vector3_t p_rLeg(0., -0.0848172440888579,-1.019272022956703);
-    rbprmDevice->setEffectorReference("talos_lleg_rom",p_lLeg);
-    rbprmDevice->setEffectorReference("talos_rleg_rom",p_rLeg);
 
 
     for(size_type i = 0 ; i < 2 ; ++i){
@@ -1157,7 +1136,7 @@ BOOST_AUTO_TEST_CASE (nav_bauzil_hard) {
 
     pSolver.initConfig(ConfigurationPtr_t(new core::Configuration_t(q_init)));
     pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
-    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),90.27,1e-2);
+    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),70.,1e-2);
 
     pSolver.solve();
     BOOST_CHECK_EQUAL(pSolver.paths().size(),2);

--- a/tests/test-kinodynamic.cc
+++ b/tests/test-kinodynamic.cc
@@ -1068,6 +1068,168 @@ BOOST_AUTO_TEST_CASE (nav_bauzil_oriented_kino) {
 }
 
 
+
+BOOST_AUTO_TEST_CASE (nav_bauzil_hyq) {
+    std::cout<<"start nav_bauzil_hyq test case, this may take a couple of minutes ..."<<std::endl;
+  // this test case may take up to a minute to execute. Usually after ~5 minutes it should be considered as a failure.
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadHyQAbsract();
+    rbprmDevice->rootJoint()->lowerBound(2, 0.62);
+    rbprmDevice->rootJoint()->upperBound(2, 0.62);
+    rbprmDevice->setDimensionExtraConfigSpace(6);
+    BindShooter bShooter;
+    std::vector<double> boundsSO3;
+    boundsSO3.push_back(-4);
+    boundsSO3.push_back(4);
+    boundsSO3.push_back(-0.1);
+    boundsSO3.push_back(0.1);
+    boundsSO3.push_back(-0.1);
+    boundsSO3.push_back(0.1);
+    bShooter.so3Bounds_ = boundsSO3;
+    hpp::core::ProblemSolverPtr_t  ps = configureRbprmProblemSolverForSupportLimbs(rbprmDevice, bShooter);
+    hpp::core::ProblemSolver& pSolver = *ps;
+    loadObstacleWithAffordance(pSolver, std::string("hpp_environments"),
+                               std::string("multicontact/floor_bauzil"),std::string("planning"));
+    // configure planner
+    pSolver.addPathOptimizer(std::string("RandomShortcutDynamic"));
+    pSolver.configurationShooterType(std::string("RbprmShooter"));
+    pSolver.pathValidationType(std::string("RbprmPathValidation"),0.05);
+    pSolver.distanceType(std::string("Kinodynamic"));
+    pSolver.steeringMethodType(std::string("RBPRMKinodynamic"));
+    pSolver.pathPlannerType(std::string("DynamicPlanner"));
+
+    // set problem parameters :
+    double aMax = 0.5;
+    double vMax = 0.3;
+    pSolver.problem()->setParameter(std::string("Kinodynamic/velocityBound"),core::Parameter(vMax));
+    pSolver.problem()->setParameter(std::string("Kinodynamic/accelerationBound"),core::Parameter(aMax));
+    pSolver.problem()->setParameter(std::string("DynamicPlanner/sizeFootX"),core::Parameter(0.01));
+    pSolver.problem()->setParameter(std::string("DynamicPlanner/sizeFootY"),core::Parameter(0.01));
+    pSolver.problem()->setParameter(std::string("DynamicPlanner/friction"),core::Parameter(0.5));
+    pSolver.problem()->setParameter(std::string("ConfigurationShooter/sampleExtraDOF"),core::Parameter(false));
+    pSolver.problem()->setParameter(std::string("PathOptimization/RandomShortcut/NumberOfLoops"),core::Parameter((core::size_type)50));
+
+
+    for(size_type i = 0 ; i < 2 ; ++i){
+      rbprmDevice->extraConfigSpace().lower(i)=-vMax;
+      rbprmDevice->extraConfigSpace().upper(i)=vMax;
+    }
+    rbprmDevice->extraConfigSpace().lower(2)=0.;
+    rbprmDevice->extraConfigSpace().upper(2)=0.;
+    for(size_type i = 3 ; i < 5 ; ++i){
+      rbprmDevice->extraConfigSpace().lower(i)=-aMax;
+      rbprmDevice->extraConfigSpace().upper(i)=aMax;
+    }
+    rbprmDevice->extraConfigSpace().lower(5)=0.;
+    rbprmDevice->extraConfigSpace().upper(5)=0.;
+
+    // define the planning problem :
+    core::Configuration_t q_init(rbprmDevice->configSize());
+    q_init << -0.2, 1.9, 0.62, 0.0, 0.0, 0.0, 1.0, 0.05, 0, 0, 0.0, 0.0, 0.0;
+    core::Configuration_t q_goal(rbprmDevice->configSize());
+    q_goal << 3.7,0.,0.62, 0,0,-0.7071,0.7071, 0., -0.1, 0, 0.0, 0.0, 0.0;
+
+    pSolver.initConfig(ConfigurationPtr_t(new core::Configuration_t(q_init)));
+    pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
+    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),50.26,1e-2);
+
+    pSolver.solve();
+    BOOST_CHECK_EQUAL(pSolver.paths().size(),2);
+    std::cout<<"Solve complete, start optimization. This may take few minutes ..."<<std::endl;
+    BOOST_CHECK(checkPathVector(pSolver.paths().back()));
+    BOOST_CHECK(checkPath(pSolver.paths().back(),0.5));
+    for(size_t i = 0 ; i < 10 ; ++i){
+      pSolver.optimizePath(pSolver.paths().back());
+      BOOST_CHECK_EQUAL(pSolver.paths().size(),3+i);
+      BOOST_CHECK(checkPathVector(pSolver.paths().back()));
+      BOOST_CHECK(checkPath(pSolver.paths().back(),0.5));
+      std::cout<<"("<<i+1<<"/10)  "<<std::flush;
+    }
+    std::cout<<std::endl;
+
+}
+
+
+BOOST_AUTO_TEST_CASE (nav_bauzil_oriented_hyq) {
+    std::cout<<"start nav_bauzil_oriented_hyq test case, this may take a couple of minutes ..."<<std::endl;
+  // this test case may take up to a minute to execute. Usually after ~5 minutes it should be considered as a failure.
+    hpp::pinocchio::RbPrmDevicePtr_t rbprmDevice = loadHyQAbsract();
+    rbprmDevice->rootJoint()->lowerBound(2, 0.62);
+    rbprmDevice->rootJoint()->upperBound(2, 0.62);
+    rbprmDevice->setDimensionExtraConfigSpace(6);
+    BindShooter bShooter;
+    std::vector<double> boundsSO3;
+    boundsSO3.push_back(-4);
+    boundsSO3.push_back(4);
+    boundsSO3.push_back(-0.1);
+    boundsSO3.push_back(0.1);
+    boundsSO3.push_back(-0.1);
+    boundsSO3.push_back(0.1);
+    bShooter.so3Bounds_ = boundsSO3;
+    hpp::core::ProblemSolverPtr_t  ps = configureRbprmProblemSolverForSupportLimbs(rbprmDevice, bShooter);
+    hpp::core::ProblemSolver& pSolver = *ps;
+    loadObstacleWithAffordance(pSolver, std::string("hpp_environments"),
+                               std::string("multicontact/floor_bauzil"),std::string("planning"));
+    // configure planner
+    pSolver.addPathOptimizer(std::string("RandomShortcutDynamic"));
+    pSolver.configurationShooterType(std::string("RbprmShooter"));
+    pSolver.pathValidationType(std::string("RbprmPathValidation"),0.05);
+    pSolver.distanceType(std::string("Kinodynamic"));
+    pSolver.steeringMethodType(std::string("RBPRMKinodynamic"));
+    pSolver.pathPlannerType(std::string("DynamicPlanner"));
+
+    // set problem parameters :
+    double aMax = 0.5;
+    double vMax = 0.3;
+    pSolver.problem()->setParameter(std::string("Kinodynamic/velocityBound"),core::Parameter(vMax));
+    pSolver.problem()->setParameter(std::string("Kinodynamic/accelerationBound"),core::Parameter(aMax));
+    pSolver.problem()->setParameter(std::string("Kinodynamic/forceOrientation"),core::Parameter(true));
+    pSolver.problem()->setParameter(std::string("DynamicPlanner/sizeFootX"),core::Parameter(0.01));
+    pSolver.problem()->setParameter(std::string("DynamicPlanner/sizeFootY"),core::Parameter(0.01));
+    pSolver.problem()->setParameter(std::string("DynamicPlanner/friction"),core::Parameter(0.5));
+    pSolver.problem()->setParameter(std::string("ConfigurationShooter/sampleExtraDOF"),core::Parameter(false));
+    pSolver.problem()->setParameter(std::string("PathOptimization/RandomShortcut/NumberOfLoops"),core::Parameter((core::size_type)50));
+
+
+    for(size_type i = 0 ; i < 2 ; ++i){
+      rbprmDevice->extraConfigSpace().lower(i)=-vMax;
+      rbprmDevice->extraConfigSpace().upper(i)=vMax;
+    }
+    rbprmDevice->extraConfigSpace().lower(2)=0.;
+    rbprmDevice->extraConfigSpace().upper(2)=0.;
+    for(size_type i = 3 ; i < 5 ; ++i){
+      rbprmDevice->extraConfigSpace().lower(i)=-aMax;
+      rbprmDevice->extraConfigSpace().upper(i)=aMax;
+    }
+    rbprmDevice->extraConfigSpace().lower(5)=0.;
+    rbprmDevice->extraConfigSpace().upper(5)=0.;
+
+    // define the planning problem :
+    core::Configuration_t q_init(rbprmDevice->configSize());
+    q_init << -0.2, 1.9, 0.62, 0.0, 0.0, 0.0, 1.0, 0.05, 0, 0, 0.0, 0.0, 0.0;
+    core::Configuration_t q_goal(rbprmDevice->configSize());
+    q_goal << 3.7,0.,0.62, 0,0,-0.7071,0.7071, 0., -0.1, 0, 0.0, 0.0, 0.0;
+
+    pSolver.initConfig(ConfigurationPtr_t(new core::Configuration_t(q_init)));
+    pSolver.addGoalConfig(ConfigurationPtr_t(new core::Configuration_t(q_goal)));
+    BOOST_CHECK_CLOSE(pSolver.robot()->mass(),50.26,1e-2);
+
+    pSolver.solve();
+    BOOST_CHECK_EQUAL(pSolver.paths().size(),2);
+    std::cout<<"Solve complete, start optimization. This may take few minutes ..."<<std::endl;
+    BOOST_CHECK(checkPathVector(pSolver.paths().back()));
+    BOOST_CHECK(checkPath(pSolver.paths().back(),0.5));
+    for(size_t i = 0 ; i < 10 ; ++i){
+      pSolver.optimizePath(pSolver.paths().back());
+      BOOST_CHECK_EQUAL(pSolver.paths().size(),3+i);
+      BOOST_CHECK(checkPathVector(pSolver.paths().back()));
+      BOOST_CHECK(checkPath(pSolver.paths().back(),0.5));
+      std::cout<<"("<<i+1<<"/10)  "<<std::flush;
+    }
+    std::cout<<std::endl;
+
+}
+
+
 /*
 // too slow to be added in the test suite ...
 BOOST_AUTO_TEST_CASE (nav_bauzil_hard) {

--- a/tests/test-projection.cc
+++ b/tests/test-projection.cc
@@ -13,7 +13,7 @@ using core::value_type;
 
 BOOST_AUTO_TEST_SUITE( test_projection)
 
-BOOST_AUTO_TEST_CASE (projectToComPosition) {
+BOOST_AUTO_TEST_CASE (projectToComPositionHyQ) {
 
   RbPrmFullBodyPtr_t fullBody = loadHyQ();
 
@@ -147,6 +147,62 @@ BOOST_AUTO_TEST_CASE (projectToComPosition) {
   }
 }
 
+/*
+BOOST_AUTO_TEST_CASE (projectToComPositionSimpleHumanoid) {
 
+  RbPrmFullBodyPtr_t fullBody = loadSimpleHumanoid();
+  const std::string rLegId("rleg");
+  const std::string lLegId("lleg");
+
+  std::vector<std::string> allLimbs;
+  allLimbs.push_back(rLegId);
+  allLimbs.push_back(lLegId);
+
+  core::Configuration_t q_ref(fullBody->device_->neutralConfiguration());
+  std::cout<<"q ref = "<<q_ref<<std::endl;
+  State s_init = createState(fullBody,q_ref,allLimbs);
+  BOOST_CHECK_EQUAL(s_init.nbContacts,2);
+  fullBody->device_->currentConfiguration(q_ref);
+  pinocchio::Computation_t newflag = static_cast <pinocchio::Computation_t> (pinocchio::JOINT_POSITION | pinocchio::JACOBIAN | pinocchio::COM);
+  fullBody->device_->controlComputation (newflag);
+  fullBody->device_->computeForwardKinematics();
+  fcl::Vec3f com_init  = fullBody->device_->positionCenterOfMass();
+  std::cout<<"com_init = "<<com_init<<std::endl;
+  fcl::Vec3f com_pino,com_goal;
+  rbprm::projection::ProjectionReport rep;
+  srand((unsigned int)(time(NULL)));
+  for(size_t k = 0 ; k < 100 ; ++k){
+    //randomly sample CoM position close to the reference one :
+    com_goal[0] = com_init[0]-0.2 + 0.4*(value_type(rand()) / value_type(RAND_MAX));
+    com_goal[1] = com_init[1]-0.2 + 0.4*(value_type(rand()) / value_type(RAND_MAX));
+    com_goal[2] = com_init[2]-0.1 + 0.2*(value_type(rand()) / value_type(RAND_MAX));
+    // check if the projection is successfull and the new com is correct
+    rep = rbprm::projection::projectToComPosition(fullBody,com_goal,s_init);
+    if(rep.success_){
+      std::cout<<"com goal : "<<com_goal<<std::endl;
+      BOOST_CHECK_EQUAL(rep.result_.nbContacts,2);
+
+      fullBody->device_->currentConfiguration(rep.result_.configuration_);
+      fullBody->device_->computeForwardKinematics();
+      com_pino  = fullBody->device_->positionCenterOfMass();
+       std::cout<<"com pino : "<<com_pino<<std::endl;
+      for(size_t i = 0 ; i < 3 ; ++i)
+        BOOST_CHECK_SMALL(com_pino[i]-com_goal[i],1e-4); // precision should be the same as the error treshold of the config projector
+
+
+      // check if contact position are preserved :
+      for(std::vector<std::string>::const_iterator cit = allLimbs.begin(); cit != allLimbs.end(); ++cit)
+       {
+        rbprm::RbPrmLimbPtr_t limb = fullBody->GetLimbs().at(*cit);
+        const std::string& limbName = *cit;
+        const fcl::Vec3f position = limb->effector_.currentTransformation().translation();
+        for(size_t i = 0 ; i < 3 ; ++i)
+          BOOST_CHECK_SMALL(position[i] - s_init.contactPositions_[limbName][i],1e-4);
+      }
+    }
+  }
+}
+
+*/
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/tools-fullbody.hh
+++ b/tests/tools-fullbody.hh
@@ -21,15 +21,19 @@
 
 #ifndef TOOLSFULLBODY_HH
 #define TOOLSFULLBODY_HH
-
+#include <hpp/core/fwd.hh>
 #include <hpp/rbprm/rbprm-fullbody.hh>
 #include <hpp/rbprm/rbprm-device.hh>
 #include <hpp/rbprm/rbprm-state.hh>
 #include <pinocchio/parsers/urdf.hpp>
 #include <hpp/pinocchio/urdf/util.hh>
+#include <hpp/pinocchio/device.hh>
+#include <hpp/pinocchio/configuration.hh>
+#include <hpp/pinocchio/simple-device.hh>
 
 using namespace hpp;
 using namespace rbprm;
+namespace pin_test = hpp::pinocchio::unittest;
 
 /*
 
@@ -57,6 +61,46 @@ fullBody.runLimbSampleAnalysis(lLegId, "ReferenceConfiguration", True)
 fullBody.setReferenceConfig (q_ref)
 
 */
+
+RbPrmFullBodyPtr_t loadSimpleHumanoid(){
+  hpp::pinocchio::DevicePtr_t device = pin_test::makeDevice(pin_test::HumanoidSimple);
+  device->rootJoint()->lowerBound(0, -2);
+  device->rootJoint()->lowerBound(1, -2);
+  device->rootJoint()->lowerBound(2, 0.4);
+  device->rootJoint()->upperBound(0,  2);
+  device->rootJoint()->upperBound(1,  2);
+  device->rootJoint()->upperBound(2,  1.2);
+
+  device->setDimensionExtraConfigSpace(6); // used by kinodynamic methods
+  for(size_type i = 0 ; i < 6 ; ++i){
+    device->extraConfigSpace().lower(i)=-5;
+    device->extraConfigSpace().upper(i)=5;
+  }
+
+  RbPrmFullBodyPtr_t fullBody = RbPrmFullBody::create(device);
+
+   // add limbs :
+  const std::string rLegId("rleg");
+  const std::string rLeg("rleg1_joint");
+  const std::string rfeet("rleg6_joint");
+  fcl::Vec3f rLegOffset( 0,0,-0.1);
+  fcl::Vec3f rLegLimbOffset(0,0,0);
+  fcl::Vec3f rLegNormal(0,0,1);
+  double legX = 0.1;
+  double legY = 0.05;
+  fullBody->AddLimb(rLegId,rLeg,rfeet,rLegOffset,rLegLimbOffset,rLegNormal,legX,legY,hpp::core::ObjectStdVector_t(),1000,"fixedStep1",0.01,hpp::rbprm::_6_DOF,false,false,std::string(),0.3);
+
+  const std::string lLegId("lleg");
+  const std::string lLeg("lleg1_joint");
+  const std::string lfeet("lleg6_joint");
+  fcl::Vec3f lLegOffset(0,0,-0.1);
+  fcl::Vec3f lLegLimbOffset(0,0,0);
+  fcl::Vec3f lLegNormal(0,0,1);
+  fullBody->AddLimb(lLegId,lLeg,lfeet,lLegOffset,lLegLimbOffset,lLegNormal,legX,legY,hpp::core::ObjectStdVector_t(),1000,"fixedStep1",0.01,hpp::rbprm::_6_DOF,false,false,std::string(),0.3);
+
+
+  return fullBody;
+}
 
 
 RbPrmFullBodyPtr_t loadHRP2(){
@@ -165,7 +209,25 @@ hpp::pinocchio::RbPrmDevicePtr_t loadHyQAbsract()
     return device;
 }
 
-
+hpp::pinocchio::RbPrmDevicePtr_t loadsimpleHumanoidAbsract(){
+    pinocchio::T_Rom romDevices_;
+    const std::string packageName("simpleHumanoid-rbprm");
+    loadRom(romDevices_, std::string("simpleHumanoid_lleg_rom"),packageName);
+    loadRom(romDevices_, std::string("simpleHumanoid_rleg_rom"),packageName);
+    hpp::pinocchio::RbPrmDevicePtr_t device =
+            loadAbstractRobot(romDevices_, std::string("simpleHumanoid_trunk"),packageName);
+    device->rootJoint()->lowerBound(0, -5);
+    device->rootJoint()->lowerBound(1, -5);
+    device->rootJoint()->lowerBound(2, 0.3);
+    device->rootJoint()->upperBound(0,  5);
+    device->rootJoint()->upperBound(1,  5);
+    device->rootJoint()->upperBound(2,  1);
+    hpp::core::vector3_t p_lLeg(0., 0.1,-1.);
+    hpp::core::vector3_t p_rLeg(0., -0.1,-1.);
+    device->setEffectorReference("simpleHumanoid_lleg_rom",p_lLeg);
+    device->setEffectorReference("simpleHumanoid_rleg_rom",p_rLeg);
+    return device;
+}
 
 hpp::pinocchio::RbPrmDevicePtr_t loadTalosLEGAbsract()
 {

--- a/tests/tools-fullbody.hh
+++ b/tests/tools-fullbody.hh
@@ -200,12 +200,20 @@ hpp::pinocchio::RbPrmDevicePtr_t loadHyQAbsract()
     loadRom(romDevices_, std::string("hyq_rhleg_rom"),packageName);
     hpp::pinocchio::RbPrmDevicePtr_t device =
             loadAbstractRobot(romDevices_, std::string("hyq_trunk_large"),packageName);
-    device->rootJoint()->lowerBound(0, -2);
-    device->rootJoint()->lowerBound(1, -1);
+    device->rootJoint()->lowerBound(0, -4);
+    device->rootJoint()->lowerBound(1, -4);
     device->rootJoint()->lowerBound(2, 0.3);
     device->rootJoint()->upperBound(0,  5);
-    device->rootJoint()->upperBound(1,  1);
-    device->rootJoint()->upperBound(2,  4);
+    device->rootJoint()->upperBound(1,  4);
+    device->rootJoint()->upperBound(2,  1);
+    hpp::core::vector3_t p_lFLeg(0.3735, 0.207 , -0.57697);
+    hpp::core::vector3_t p_rFLeg(0.3735, -0.207 , -0.57697);
+    hpp::core::vector3_t p_lHLeg(-0.3735, 0.207 , -0.57697);
+    hpp::core::vector3_t p_rHLeg(-0.3735, -0.207 , -0.57697);
+    device->setEffectorReference("hyq_lfleg_rom",p_lFLeg);
+    device->setEffectorReference("hyq_rfleg_rom",p_rFLeg);
+    device->setEffectorReference("hyq_lhleg_rom",p_lHLeg);
+    device->setEffectorReference("hyq_rhleg_rom",p_rHLeg);
     return device;
 }
 


### PR DESCRIPTION
* Add a 'simpleHumanoid' in test-tools

* Kinodynamic : use simpleHumanoid and hyq instead of talos

* Reachability temporarily commented (need to be updated with https://github.com/laas/simple_humanoid_description or the new robot for unit test in pinocchio V 2)