### PR TITLE
Change reachability API for quasiStatic methods

### DIFF
--- a/include/hpp/rbprm/contact_generation/reachability.hh
+++ b/include/hpp/rbprm/contact_generation/reachability.hh
@@ -82,7 +82,7 @@ namespace hpp {
 
 std::pair<MatrixXX, VectorX> stackConstraints(const std::pair<MatrixXX, VectorX> &Ab, const std::pair<MatrixXX, VectorX> &Cd);
 
-bool intersectionExist(const std::pair<MatrixXX, VectorX>& Ab, const fcl::Vec3f& c0, const fcl::Vec3f& c1, fcl::Vec3f &c_out);
+bool intersectionExist(const std::pair<MatrixXX, VectorX>& Ab, const fcl::Vec3f& c, fcl::Vec3f &c_out);
 
 std::pair<MatrixXX, VectorX> computeStabilityConstraints(const centroidal_dynamics::Equilibrium& contactPhase,const fcl::Vec3f& int_point = fcl::Vec3f(0,0,0),const fcl::Vec3f& acc = fcl::Vec3f(0,0,0));
 
@@ -90,7 +90,17 @@ std::pair<MatrixXX, VectorX> computeStabilityConstraintsForState(const RbPrmFull
 
 std::pair<MatrixXX, VectorX> computeConstraintsForState(const RbPrmFullBodyPtr_t& fullbody, State &state,bool& success);
 
-Result isReachable(const RbPrmFullBodyPtr_t& fullbody,State &previous, State& next,const fcl::Vec3f& acc = fcl::Vec3f::Zero());
+/**
+ * @brief isReachable Compute the feasibility of the contact transition between the two state, with the quasiStatic formulation of 2-PAC (https://hal.archives-ouvertes.fr/hal-01609055)
+ * @param fullbody
+ * @param previous the first state of the transition
+ * @param next the last state of the transition
+ * @param acc the CoM acceleration
+ * @param useIntermediateState boolean only relevant in the case of a contact repositionning. If true, use an intermediate state such that there is only one contact change between each state.
+ *                              (and thus compute two intersection between 3 set of constrants). If false it only compute one intersection between two set of constraints.
+ * @return
+ */
+Result isReachable(const RbPrmFullBodyPtr_t& fullbody,State &previous, State& next,const fcl::Vec3f& acc = fcl::Vec3f::Zero(), bool useIntermediateState = false);
 
 Result isReachableDynamic(const RbPrmFullBodyPtr_t& fullbody, State &previous, State& next, bool tryQuasiStatic = false, std::vector<double> timings = std::vector<double>(), int numPointsPerPhases = 0);
 

--- a/src/contact_generation/reachability.cc
+++ b/src/contact_generation/reachability.cc
@@ -535,8 +535,8 @@ Result isReachableDynamic(const RbPrmFullBodyPtr_t& fullbody, State &previous, S
     pData.dc1_ = next.configuration_.segment<3>(id_velocity);
     pData.ddc0_ = previous.configuration_.segment<3>(id_velocity+3); // unused for now
     pData.ddc1_ = next.configuration_.segment<3>(id_velocity+3);
-    pData.dc0_ = fcl::Vec3f::Zero();
-    pData.dc1_ = fcl::Vec3f::Zero();
+    //pData.dc0_ = fcl::Vec3f::Zero();
+   // pData.dc1_ = fcl::Vec3f::Zero();
     pData.ddc0_ = fcl::Vec3f::Zero();
     pData.ddc1_ = fcl::Vec3f::Zero();
     hppDout(notice,"Build pData : ");

--- a/src/contact_generation/reachability.cc
+++ b/src/contact_generation/reachability.cc
@@ -347,7 +347,9 @@ Result isReachable(const RbPrmFullBodyPtr_t& fullbody, State &previous, State& n
     for(std::map<std::string,fcl::Vec3f>::const_iterator cit = smaller_state.contactPositions_.begin();
           cit!=smaller_state.contactPositions_.end(); ++ cit)
     {
-      c_robust += cit->second;
+      fcl::Transform3f jointT( smaller_state.contactRotation_.at(cit->first), cit->second);
+      fcl::Vec3f position =  jointT.transform(fullbody->GetLimb(cit->first)->offset_);
+      c_robust += position;
     }
     c_robust /=(fcl::FCL_REAL)smaller_state.contactPositions_.size();
     c_robust[2] = (com_previous[2] + com_next[2])/2.;

--- a/src/contact_generation/reachability.cc
+++ b/src/contact_generation/reachability.cc
@@ -384,10 +384,10 @@ Result isReachable(const RbPrmFullBodyPtr_t& fullbody, State &previous, State& n
     else{
         if(contactsBreak.size() > 0){
             int_pt_kin = com_previous;
-            intersectionExist(A_n,com_previous,com_next,int_pt_stab);
+            intersectionExist(A_n,(com_previous+com_next)/2.,int_pt_stab);
         }else{
             int_pt_kin = com_next;
-            intersectionExist(A_p,com_previous,com_next,int_pt_stab);
+            intersectionExist(A_p,(com_previous+com_next)/2.,int_pt_stab);
         }
     }
 

--- a/src/contact_generation/reachability.cc
+++ b/src/contact_generation/reachability.cc
@@ -98,12 +98,10 @@ std::pair<MatrixXX, VectorX> computeDistanceCost(const fcl::Vec3f& c0){
     return std::make_pair(H,g);
 }
 
-bool intersectionExist(const std::pair<MatrixXX, VectorX> &Ab, const fcl::Vec3f& c0, const fcl::Vec3f& c1, fcl::Vec3f& c_out){
-    fcl::Vec3f init = (c0+c1)/2.;
-
+bool intersectionExist(const std::pair<MatrixXX, VectorX> &Ab, const fcl::Vec3f& c, fcl::Vec3f& c_out){
     hppDout(notice,"Call solveur solveIntersection");
-    hppDout(notice,"init = "<<init);
-    bezier_com_traj::ResultData res = bezier_com_traj::solve(Ab,computeDistanceCost(c0),init);
+    hppDout(notice,"init = "<<c);
+    bezier_com_traj::ResultData res = bezier_com_traj::solve(Ab,computeDistanceCost(c),c);
     c_out = res.x;
     hppDout(notice,"success Solveur solveIntersection = "<<res.success_);
     hppDout(notice,"x = ["<<c_out[0]<<","<<c_out[1]<<","<<c_out[2]<<"]");
@@ -324,7 +322,7 @@ Result isReachable(const RbPrmFullBodyPtr_t& fullbody, State &previous, State& n
 
     fcl::Vec3f x;
     hppStartBenchmark(QP_REACHABLE);
-    success = intersectionExist(Ab,com_previous,com_next,x);
+    success = intersectionExist(Ab,(com_previous+com_next)/2.,x);
     hppStopBenchmark(QP_REACHABLE);
     hppDisplayBenchmark(QP_REACHABLE);
     if(success){

--- a/src/contact_generation/reachability.cc
+++ b/src/contact_generation/reachability.cc
@@ -217,6 +217,8 @@ Result isReachableIntermediate(const RbPrmFullBodyPtr_t& fullbody,State &previou
 
 Result isReachable(const RbPrmFullBodyPtr_t& fullbody, State &previous, State& next,const fcl::Vec3f& acc){
     hppStartBenchmark(IS_REACHABLE);
+    assert(previous.nbContacts > 0 && "Reachability : previous state have less than 1 contact.");
+    assert(next.nbContacts > 0 && "Reachability : next state have less than 1 contact.");
     std::vector<std::string> contactsCreation, contactsBreak;
     next.contactBreaks(previous,contactsBreak);
     next.contactCreations(previous,contactsCreation);

--- a/src/contact_generation/reachability.cc
+++ b/src/contact_generation/reachability.cc
@@ -590,15 +590,15 @@ Result isReachableDynamic(const RbPrmFullBodyPtr_t& fullbody, State &previous, S
           current_timings<<1.,1.;
         }
       #else
-        timings_matrix = MatrixXX(16,3); // contain the timings of the first 3 phases, the total time and the discretization step
+        timings_matrix = MatrixXX(18,3); // contain the timings of the first 3 phases, the total time and the discretization step
         timings_matrix <<
-                          0.8 , 0.7, 0.8,
+            0.6, 1.2, 0.6,
+             1. , 1.2, 1.,
+            0.8 , 0.7, 0.8,
             0.3 , 0.6, 0.3,
             0.5 , 0.6, 0.5,
             0.6 , 0.6, 0.6,
             0.8 , 0.6, 0.8,
-            0.6, 1.2, 0.6,
-            1. , 1.2, 1.,
             0.3 , 0.8, 0.3,
             0.3 , 0.7, 0.3,
             0.6 , 0.8, 0.6,
@@ -607,7 +607,9 @@ Result isReachableDynamic(const RbPrmFullBodyPtr_t& fullbody, State &previous, S
             0.8,0.8,0.8, // script good
             1. , 0.6, 1.,
             1.2 , 0.6, 1.2,
-            1.5 , 0.6, 1.5;
+            1.5 , 0.6, 1.5,
+            0.1 , 0.2, 0.1,
+            0.2, 0.3, 0.2;
         current_timings = timings_matrix.block(0,0,1,pData.contacts_.size()).transpose();
       #endif
       total_time = 0;


### PR DESCRIPTION
* Add optional argument to force the computation of only one intersection, even in the case of a contact repositionning (false by default to keep the previous behavior)
* Improve API of intersectionExist for the cost function : min distance to a specified point
* Use the center of the support polygon of the phase with the fewer contacts (with a z value equal to the average of the CoM height between the init and final state) as the point used by for cost function