### PR TITLE
Devel

### DIFF
--- a/include/hpp/rbprm/interpolation/rbprm-path-interpolation.hh
+++ b/include/hpp/rbprm/interpolation/rbprm-path-interpolation.hh
@@ -93,6 +93,8 @@ namespace hpp {
         /// \return the input list with the last states modified and the goal state added
         ///
         rbprm::T_StateFrame addGoalConfig(const rbprm::T_StateFrame& states);
+        rbprm::T_StateFrame addGoalConfigRec(const rbprm::T_StateFrame& states,const std::vector<std::string> variations);
+
 
     public:
         const core::PathVectorConstPtr_t path_;

--- a/include/hpp/rbprm/interpolation/time-constraint-steering.hh
+++ b/include/hpp/rbprm/interpolation/time-constraint-steering.hh
@@ -35,7 +35,7 @@ namespace hpp {
     /// Apply some configuration validation algorithms at discretized values
     /// of the path parameter.
     template<class Path_T>
-    class TimeConstraintSteering: public hpp::core::SteeringMethod
+    class TimeConstraintSteering: public hpp::core::steeringMethod::Straight
     {
     typedef Path_T path_t;
     typedef boost::shared_ptr <TimeConstraintSteering> TimeConstraintSteeringPtr_t;
@@ -98,7 +98,7 @@ namespace hpp {
       /// Weighed distance is created from robot
       TimeConstraintSteering (const core::ProblemPtr_t& problem,
                        const std::size_t pathDofRank) :
-    SteeringMethod (*problem), pathDofRank_(pathDofRank), weak_ () {}
+    core::steeringMethod::Straight(*problem), pathDofRank_(pathDofRank), weak_ () {}
 
       /*/// Constructor with weighed distance
       TimeConstraintSteering (const core::DevicePtr_t& device,
@@ -110,12 +110,12 @@ namespace hpp {
       }*/
       /// Copy constructor
       TimeConstraintSteering (const TimeConstraintSteering& other) :
-    SteeringMethod (other), pathDofRank_(other.pathDofRank_), weak_ (), tds_(other.tds_) {}
+    core::steeringMethod::Straight (other), pathDofRank_(other.pathDofRank_), weak_ (), tds_(other.tds_) {}
 
       /// Store weak pointer to itself
       void init (TimeConstraintSteeringWkPtr_t weak)
       {
-    SteeringMethod::init (weak);
+    core::steeringMethod::Straight::init (weak);
     weak_ = weak;
       }
 

--- a/include/hpp/rbprm/planner/dynamic-planner.hh
+++ b/include/hpp/rbprm/planner/dynamic-planner.hh
@@ -107,7 +107,6 @@ private:
     bool rectangularContact_;
     bool tryJump_;
     double mu_;
-    std::map<std::string,fcl::Vec3f> rom_ref_endEffector_;
 };
 /// \}
 } // namespace core

--- a/include/hpp/rbprm/projection/projection.hh
+++ b/include/hpp/rbprm/projection/projection.hh
@@ -82,9 +82,9 @@ ProjectionReport HPP_RBPRM_DLLAPI projectSampleToObstacle(const hpp::rbprm::RbPr
                                                  const sampling::OctreeReport& report, core::CollisionValidationPtr_t validation,
                                                  pinocchio::ConfigurationOut_t configuration, const hpp::rbprm::State& current);
 
-ProjectionReport HPP_RBPRM_DLLAPI projectEffector(core::ConfigProjectorPtr_t proj, const hpp::rbprm::RbPrmFullBodyPtr_t& body,const std::string& limbId, const hpp::rbprm::RbPrmLimbPtr_t& limb,
+ProjectionReport HPP_RBPRM_DLLAPI projectEffector(core::ConfigProjectorPtr_t proj, const hpp::rbprm::RbPrmFullBodyPtr_t& body, const std::string& limbId, const hpp::rbprm::RbPrmLimbPtr_t& limb,
                                            core::CollisionValidationPtr_t validation, pinocchio::ConfigurationOut_t configuration,
-                                           const fcl::Matrix3f& rotationTarget, const std::vector<bool>& rotationFilter, const fcl::Vec3f& positionTarget, const fcl::Vec3f& normal,
+                                           const fcl::Matrix3f& rotationTarget, std::vector<bool> rotationFilter, const fcl::Vec3f& positionTarget, const fcl::Vec3f& normal,
                                            const hpp::rbprm::State& current);
 
 fcl::Transform3f HPP_RBPRM_DLLAPI  computeProjectionMatrix(const hpp::rbprm::RbPrmFullBodyPtr_t& body, const hpp::rbprm::RbPrmLimbPtr_t& limb, const pinocchio::ConfigurationIn_t configuration,

--- a/include/hpp/rbprm/projection/projection.hh
+++ b/include/hpp/rbprm/projection/projection.hh
@@ -73,10 +73,10 @@ ProjectionReport  HPP_RBPRM_DLLAPI setCollisionFree(hpp::rbprm::RbPrmFullBodyPtr
 
 
 ProjectionReport HPP_RBPRM_DLLAPI projectStateToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& body, const std::string& limbId, const hpp::rbprm::RbPrmLimbPtr_t& limb,
-                                                         const hpp::rbprm::State& current, const fcl::Vec3f &normal, const fcl::Vec3f &position);
+                                                         const hpp::rbprm::State& current, const fcl::Vec3f &normal, const fcl::Vec3f &position,bool lockOtherJoints = false);
 
 ProjectionReport HPP_RBPRM_DLLAPI projectStateToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& body, const std::string& limbId, const hpp::rbprm::RbPrmLimbPtr_t& limb,
-                                                         const hpp::rbprm::State& current, const fcl::Vec3f &normal, const fcl::Vec3f &position, core::CollisionValidationPtr_t validation);
+                                                         const hpp::rbprm::State& current, const fcl::Vec3f &normal, const fcl::Vec3f &position, core::CollisionValidationPtr_t validation, bool lockOtherJoints = false);
 
 ProjectionReport HPP_RBPRM_DLLAPI projectSampleToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& body,const std::string& limbId, const hpp::rbprm::RbPrmLimbPtr_t& limb,
                                                  const sampling::OctreeReport& report, core::CollisionValidationPtr_t validation,

--- a/include/hpp/rbprm/rbprm-fullbody.hh
+++ b/include/hpp/rbprm/rbprm-fullbody.hh
@@ -136,6 +136,8 @@ namespace hpp {
         void referenceConfig(pinocchio::Configuration_t referenceConfig);
         pinocchio::Configuration_t postureWeights(){return postureWeights_;}
         void postureWeights(pinocchio::Configuration_t postureWeights);
+        bool usePosturalTaskContactCreation(){return usePosturalTaskContactCreation_;}
+        void usePosturalTaskContactCreation(bool usePosturalTaskContactCreation){usePosturalTaskContactCreation_ = usePosturalTaskContactCreation;}
         bool addEffectorTrajectory(const size_t pathId,const std::string& effectorName,const bezier_Ptr& trajectory);
         bool addEffectorTrajectory(const size_t pathId, const std::string& effectorName, const std::vector<bezier_Ptr>& trajectories);
         bool getEffectorsTrajectories(const size_t pathId,EffectorTrajectoriesMap_t& result);
@@ -152,6 +154,7 @@ namespace hpp {
         double mu_;
         pinocchio::Configuration_t reference_;
         pinocchio::Configuration_t postureWeights_; // weight used to compute the distance in the postural tasks
+        bool usePosturalTaskContactCreation_; // if true, during the contact creation the orientation of the feet along the contact normal is optimized for a postural task
         std::map<size_t,EffectorTrajectoriesMap_t> effectorsTrajectoriesMaps_; // the map link the pathIndex (the same as in the wholeBody paths in problem solver) to a map of trajectories for each effectors.
     private:
         void AddLimbPrivate(rbprm::RbPrmLimbPtr_t limb, const std::string& id, const std::string& name,

--- a/src/contact_generation/contact_generation.cc
+++ b/src/contact_generation/contact_generation.cc
@@ -143,7 +143,13 @@ Q_State maintain_contacts_combinatorial(const hpp::rbprm::State& currentState, c
 {
     T_DepthState res(maxBrokenContacts+1);
     hppDout(notice,"maintain contact combinatorial : ");
-    maintain_contacts_combinatorial_rec(currentState, 0, maxBrokenContacts,res);
+    if(currentState.nbContacts == 1){
+      res[0].push_back(currentState);
+      hppDout(warning,"Maintain_contacts_combinatorial called with a state with only 1 contact. FIXME, why does it happen ? ");
+    }
+    else{
+      maintain_contacts_combinatorial_rec(currentState, 0, maxBrokenContacts,res);
+     }
     return flatten(res);
 }
 

--- a/src/contact_generation/contact_generation.cc
+++ b/src/contact_generation/contact_generation.cc
@@ -515,6 +515,7 @@ hpp::rbprm::State findValidCandidate(const ContactGenHelper &contactGenHelper, c
                         reachability::Result resReachability;
                         if(contactGenHelper.quasiStatic_){
                             resReachability = reachability::isReachable(contactGenHelper.fullBody_,intermediateState,rep.result_);
+                            //resReachability = reachability::isReachable(contactGenHelper.fullBody_,previous,rep.result_); // TODO : use a parameter to choose between both cases
                         }else{
                             hppStartBenchmark(REACHABILITY_CONTACT);
                             resReachability = reachability::isReachableDynamic(contactGenHelper.fullBody_,previous,rep.result_,contactGenHelper.tryQuasiStatic_,std::vector<double>(),contactGenHelper.reachabilityPointPerPhases_);

--- a/src/interpolation/com-rrt.cc
+++ b/src/interpolation/com-rrt.cc
@@ -36,7 +36,7 @@ using namespace core;
     void SetComRRTConstraints::operator ()(ComRRTHelper& helper, const State& from, const State& to) const
     {
         CreateContactConstraints<ComRRTHelper>(helper, from, to);
-        CreateComConstraint<ComRRTHelper,core::PathPtr_t>(helper, helper.refPath_);
+        //CreateComConstraint<ComRRTHelper,core::PathPtr_t>(helper, helper.refPath_);
         // add postural task to respect the constraint during all the motion but greatly increase computation time
         // FIXME : can lead to discontinuities ...
       /*  Configuration_t refConfig = helper.fullbody_->referenceConfig();

--- a/src/interpolation/rbprm-path-interpolation.cc
+++ b/src/interpolation/rbprm-path-interpolation.cc
@@ -81,15 +81,65 @@ namespace hpp {
         return Interpolate(affordances, affFilters, configs, robustnessTreshold, timeStep, range.first, filterStates);
     }
 
+    ///
+    /// \brief replaceLimbContactForState Try to create a state with all the contacts of stateCurrent, except for LimbId which have the contact of stateGoal
+    /// \param robot
+    /// \param stateCurrent
+    /// \param stateGoal
+    /// \param limbId
+    /// \return a projection report
+    ///
+    projection::ProjectionReport replaceLimbContactForState(RbPrmFullBodyPtr_t robot, State stateCurrent, State stateGoal,std::string limbId){
+      stateCurrent.RemoveContact(limbId);
+      hppDout(notice,"Try to replace contact for limb : "<<limbId);
+      pinocchio::Configuration_t configuration = stateCurrent.configuration_;
+      core::ConfigProjectorPtr_t proj = core::ConfigProjector::create(robot->device_,"proj", 1e-4, 1000);
+      interpolation::addContactConstraints(robot, robot->device_,proj, stateCurrent, stateCurrent.fixedContacts(stateCurrent));
+      std::vector<bool> rotationMaskGoal;
+      for(std::size_t i =0; i <3; ++i)
+      {
+          rotationMaskGoal.push_back(true);
+      }
+      return projection::projectEffector(proj,robot,limbId,robot->GetLimb(limbId),robot->GetCollisionValidation(),configuration,stateGoal.contactRotation_.at(limbId),rotationMaskGoal,stateGoal.contactPositions_.at(limbId),stateGoal.contactNormals_.at(limbId),stateCurrent);
+    }
+
+    // greedy algorithm to try the combination of order to move the legs until a successfull one is found
+    rbprm::T_StateFrame RbPrmInterpolation::addGoalConfigRec(const rbprm::T_StateFrame& states, const std::vector<std::string> variations){
+        hppDout(notice,"addGoalConfigRec, variations size : "<<variations.size());
+        if(variations.size() == 1){
+          return states;
+        }
+        State midStateGoal(states.back().second);
+        projection::ProjectionReport projReport;
+        for(size_t id = 0 ; id < variations.size() ; ++id){
+            std::string limbId(variations[id]);
+            hppDout(notice,"addGoalConfigRec, try to move limb : "<<limbId);
+            projReport = replaceLimbContactForState(robot_,midStateGoal,end_,limbId);
+            // If projection was successful, we add the new intermediate state to the results
+            if(projReport.success_){
+                hppDout(notice,"projection of contact successful");
+                hppDout(notice,"New intermediate state : "<<pinocchio::displayConfig(projReport.result_.configuration_));
+                rbprm::T_StateFrame results(states.begin(),states.end()); // copy input states
+                results.push_back(std::make_pair(states.back().first,projReport.result_)); // there will be 2 states at the same time index ...
+                std::vector<std::string> remainingVariations(variations);
+                remainingVariations.erase(remainingVariations.begin()+id);
+                return addGoalConfigRec(results,remainingVariations);
+            }else{
+              hppDout(notice,"addGoalConfigRec projection failed for limb "<<limbId);
+            }
+        } // all projections failed, return original list
+        return states;
+    }
+
+    // Try to add the desired final configuration at the end of the current contact sequence, while guaranteing that there is always only one contact variation between states
     rbprm::T_StateFrame RbPrmInterpolation::addGoalConfig(const rbprm::T_StateFrame& states){
         hppDout(notice,"AddGoalConfig, size of state list : "<<states.size());
-        // First, we change the contact created between the last and last-1 state to match the contact position of the specified goal state :
-        rbprm::T_StateFrame results(states.begin(),states.end()); // copy input states exept the last one
+        rbprm::T_StateFrame results(states.begin(),states.end()); // copy input states
         State lastState = states.back().second;
 
 
-        std::vector<std::string> variationsGoal(lastState.contactVariations(end_));
-        if(variationsGoal.size() <1){
+        std::vector<std::string> variationsGoal(lastState.contactVariations(end_)); // all limb that must be moved to reach the goal configuration
+        if(variationsGoal.size() ==0){
           hppDout(notice,"no contact variation, return input list");
           return results;
         }else if(variationsGoal.size() == 1){
@@ -97,34 +147,10 @@ namespace hpp {
           results.push_back(std::make_pair(states.back().first,end_)); // there will be 2 states at the same time index ...
           return results;
         }
-        core::ConfigProjectorPtr_t proj;
-        pinocchio::Configuration_t configuration;
-        projection::ProjectionReport projReport;
         // Last state and end are not adjacent, we keep lastState in the list and produce intermediate states for each contact transition
         hppDout(notice," Last state and end are not adjacent, try to add intermediate state");
-        for(size_t id = 0 ; id < variationsGoal.size()-1 ; ++id){
-          // for each different contact, try to replace to it's position in end_ and add an intermediate state
-          // FIXME: to be complete, the combinatorial of the order of projection in case of failure should be implemented ...
-          std::string limbIdGoal(variationsGoal[id]);
-          State midStateGoal(results.back().second);
-          midStateGoal.RemoveContact(limbIdGoal);
-          hppDout(notice,"Try to replace contact for limb : "<<limbIdGoal);
-          configuration = midStateGoal.configuration_;
-          proj = core::ConfigProjector::create(robot_->device_,"proj", 1e-4, 1000);
-          interpolation::addContactConstraints(robot_, robot_->device_,proj, midStateGoal, midStateGoal.fixedContacts(midStateGoal));
-          std::vector<bool> rotationMaskGoal;
-          for(std::size_t i =0; i <3; ++i)
-          {
-              rotationMaskGoal.push_back(true);
-          }
-          projReport = projection::projectEffector(proj,robot_,limbIdGoal,robot_->GetLimb(limbIdGoal),robot_->GetCollisionValidation(),configuration,end_.contactRotation_.at(limbIdGoal),rotationMaskGoal,end_.contactPositions_.at(limbIdGoal),end_.contactNormals_.at(limbIdGoal),midStateGoal);
-          // If projection was successful, we add the new intermediate state to the results
-          if(projReport.success_){
-              hppDout(notice,"projection of contact successful");
-              hppDout(notice,"New intermediate state : "<<pinocchio::displayConfig(projReport.result_.configuration_));
-              results.push_back(std::make_pair(states.back().first,projReport.result_)); // there will be 2 states at the same time index ...
-          }
-        }
+        // for each different contact, try to replace to it's position in end_ and add an intermediate state
+        results = addGoalConfigRec(states,variationsGoal);
         if((results.back().second.contactVariations(end_)).size() == 1){
           hppDout(notice,"LastState is adjacent to goal, add it to the list and return");
           results.push_back(std::make_pair(path_->timeRange().second,end_));

--- a/src/interpolation/rbprm-path-interpolation.cc
+++ b/src/interpolation/rbprm-path-interpolation.cc
@@ -137,7 +137,6 @@ namespace hpp {
         rbprm::T_StateFrame results(states.begin(),states.end()); // copy input states
         State lastState = states.back().second;
 
-
         std::vector<std::string> variationsGoal(lastState.contactVariations(end_)); // all limb that must be moved to reach the goal configuration
         if(variationsGoal.size() ==0){
           hppDout(notice,"no contact variation, return input list");
@@ -147,6 +146,8 @@ namespace hpp {
           results.push_back(std::make_pair(states.back().first,end_)); // there will be 2 states at the same time index ...
           return results;
         }
+        const bool usePosturalTask = robot_->usePosturalTaskContactCreation();
+        robot_->usePosturalTaskContactCreation(false); // temporary disable this setting for projecting exactly on the goal config
         // Last state and end are not adjacent, we keep lastState in the list and produce intermediate states for each contact transition
         hppDout(notice," Last state and end are not adjacent, try to add intermediate state");
         // for each different contact, try to replace to it's position in end_ and add an intermediate state
@@ -157,6 +158,7 @@ namespace hpp {
         }else{
           hppDout(notice,"LastState is still not adjacent to goal, contact sequence do not end with the goal state");
         }
+        robot_->usePosturalTaskContactCreation(usePosturalTask); // put back previous setting
         return results;
     }
 

--- a/src/interpolation/time-constraint-path.cc
+++ b/src/interpolation/time-constraint-path.cc
@@ -146,10 +146,14 @@ namespace hpp {
       Configuration_t endc = end();
       vector_t errr;
       updateConstraints(initc);
+      hppDout(notice,"Check path, init = "<<pinocchio::displayConfig(initc));
+      hppDout(notice,"Check path, end  = "<<pinocchio::displayConfig(endc));
+
       if (constraints()) {
         if (!constraints()->isSatisfied (initial(),errr)) {
             device_->currentConfiguration(initc);
             device_->computeForwardKinematics();
+            hppDout(notice,"Ini com : "<<device_->positionCenterOfMass()<<"  error : "<<errr);
 //std::cout << "init conf " <<  device_->positionCenterOfMass() << "\n error \n" << errr << std::endl;
 /*device_->currentConfiguration(initc);
 device_->computeForwardKinematics();
@@ -165,13 +169,15 @@ std::cout <<  device_->getJointByName("rh_foot_joint")->currentTransformation().
 std::cout << "lh_foot_joint  " << std::endl;
 std::cout <<  device_->getJointByName("lh_foot_joint")->currentTransformation().getTranslation() << std::endl;*/
           hppDout (error,"Initial configuration of path does not satisfy the constraints" << pinocchio::displayConfig(initial()));
-          hppDout(info,"Error = "<<errr);
           throw projection_error ("Initial configuration of path does not satisfy "
               "the constraints");
         }
         updateConstraints(endc);
-        if (constraints() && !constraints()->isSatisfied (end())) {
+        if (constraints() && !constraints()->isSatisfied (end(),errr)) {
 //std::cout << "end conf " <<  initc << std::endl;
+          device_->currentConfiguration(endc);
+          device_->computeForwardKinematics();
+          hppDout(notice,"End com : "<<device_->positionCenterOfMass()<<"  error : "<<errr);
           hppDout (error,"End configuration of path does not satisfy the constraints"<< pinocchio::displayConfig(end()));
           throw projection_error ("End configuration of path does not satisfy "
               "the constraints");

--- a/src/planner/dynamic-planner.cc
+++ b/src/planner/dynamic-planner.cc
@@ -108,21 +108,6 @@ namespace hpp {
           mu_ = problem.getParameter (std::string("DynamicPlanner/friction")).floatValue();
           hppDout(notice,"mu define in python : "<<mu_);
 
-          // create the map of end effector reference position in root frame
-          pinocchio::RbPrmDevicePtr_t rbDevice = boost::dynamic_pointer_cast<pinocchio::RbPrmDevice>(problem.robot());
-          for(pinocchio::T_Rom::const_iterator itr = rbDevice->robotRoms_.begin() ; itr != rbDevice->robotRoms_.end() ; ++itr){
-            core::Configuration_t pos(3);
-            try{
-                pos[0] = problem.getParameter (std::string(itr->first+"_ref_x")).floatValue();
-                pos[1] = problem.getParameter (std::string(itr->first+"_ref_y")).floatValue();
-                pos[2] = problem.getParameter (std::string(itr->first+"_ref_z")).floatValue();
-            }catch (const std::exception& e) {
-                hppDout(notice,"No reference position for end effector contact defined for the ROM "<<itr->first);
-            }
-            rom_ref_endEffector_.insert(std::make_pair(itr->first,pos));
-            hppDout(notice,"Reference end effector position for rom : "<<itr->first);
-            hppDout(notice,""<<pinocchio::displayConfig(pos));
-          }
 
 
     }
@@ -153,22 +138,6 @@ namespace hpp {
       mu_ = problem.getParameter (std::string("DynamicPlanner/friction")).floatValue();
       hppDout(notice,"mu define in python : "<<mu_);
 
-
-      // create the map of end effector reference position in root frame
-      pinocchio::RbPrmDevicePtr_t rbDevice = boost::dynamic_pointer_cast<pinocchio::RbPrmDevice>(problem.robot());
-      for(pinocchio::T_Rom::const_iterator itr = rbDevice->robotRoms_.begin() ; itr != rbDevice->robotRoms_.end() ; ++itr){
-        fcl::Vec3f pos = fcl::Vec3f::Zero();
-        try{
-            pos[0] = problem.getParameter (std::string(itr->first+"_ref_x")).floatValue();
-            pos[1] = problem.getParameter (std::string(itr->first+"_ref_y")).floatValue();
-            pos[2] = problem.getParameter (std::string(itr->first+"_ref_z")).floatValue();
-        }catch (const std::exception& e) {
-            hppDout(notice,"No reference position for end effector contact defined for the ROM "<<itr->first);
-        }
-        rom_ref_endEffector_.insert(std::make_pair(itr->first,pos));
-        hppDout(notice,"Reference end effector position for rom : "<<itr->first);
-        hppDout(notice,""<<pos);
-      }
 
     }
 

--- a/src/planner/dynamic-planner.cc
+++ b/src/planner/dynamic-planner.cc
@@ -468,13 +468,8 @@ namespace hpp {
          // roadmap ()->addEdge (initNode, *itn, validPath);  // (TODO a supprimer)display the path no matter if it's successful or not
 
           if (pathValid && validPath->timeRange ().second !=
-              path->timeRange ().first) {
-            if(validPath->end() == *((*itn)->configuration())){
+              path->timeRange ().first) { // connection to goal config successfull, add the edge
               roadmap ()->addEdge (initNode, *itn, projPath);
-            }else{
-              core::ConfigurationPtr_t q_jump(new core::Configuration_t(validPath->end()));
-              roadmap()->addNodeAndEdge(initNode,q_jump,validPath);
-            }
           }else if (validPath){
             if(tryJump_){
               std::vector<std::string> filter;
@@ -495,7 +490,7 @@ namespace hpp {
               }else{
                 hppDout(notice,"trunk in collision");
               }
-            }else if(validPath->timeRange ().second !=  path->timeRange ().first){
+            }else if(validPath->timeRange ().second !=  path->timeRange ().first){ // add the last valid configu reached to the roadmap
               core::ConfigurationPtr_t q_new(new core::Configuration_t(validPath->end()));
               core::NodePtr_t x_new = roadmap()->addNodeAndEdge(initNode,q_new,validPath);
               computeGIWC(x_new);

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -340,6 +340,7 @@ ProjectionReport projectEffector(hpp::core::ConfigProjectorPtr_t proj, const hpp
     if(body->usePosturalTaskContactCreation()){
       CreatePosturalTaskConstraint(body,proj);
       proj->errorThreshold(1e-3);
+      proj->maxIterations(1000);
       proj->lastIsOptional(true);
     }
 

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -126,10 +126,8 @@ void CreateComPosConstraint(hpp::rbprm::RbPrmFullBodyPtr_t fullBody, const fcl::
 }
 
 void CreatePosturalTaskConstraint(hpp::rbprm::RbPrmFullBodyPtr_t fullBody,core::ConfigProjectorPtr_t proj){
-  hppDout(notice,"create postural task, in projection.cc, ref config = "<<pinocchio::displayConfig(fullBody->referenceConfig()));
+  //hppDout(notice,"create postural task, in projection.cc, ref config = "<<pinocchio::displayConfig(fullBody->referenceConfig()));
   std::vector <bool> mask (fullBody->device_->numberDof(),false);
-  Configuration_t weight(fullBody->device_->numberDof());
-
   // mask : 0 for the freeflyer and the extraDoFs :
   for(size_t i = 0 ; i < 3 ; i++){
     mask[i]=false;
@@ -138,34 +136,22 @@ void CreatePosturalTaskConstraint(hpp::rbprm::RbPrmFullBodyPtr_t fullBody,core::
     mask[i]=false;
   }
 
-
-
-
-  // create a weight vector
-  for(size_type i = 0 ; i < fullBody->device_->numberDof() ; ++i){
-    weight[i] = 1.;
-  }
-  // TODO : retrieve it from somewhere, store it in fullbody ?
-  // value here for hrp2, from Justin
-  // : chest
-  weight[6]= 10.;
-  //head :
-  for(size_type i = 7 ; i <= 9 ; i++)
-    weight[i] = 1.;
-
-  // root's orientation
-  for(size_type i = 3 ; i < 6 ; i++){
-    weight[i] = 50.;
-  }
-
   /*for(size_t i = 3 ; i <= 9 ; i++){
     mask[i] = true;
   }*/
  // mask[5] = false; // z root rotation ????
 
+  Configuration_t weight(fullBody->device_->numberDof());
+  if(fullBody->postureWeights().size() == fullBody->device_->numberDof()){
+    weight = fullBody->postureWeights();
+  }else{
+    for(size_type i = 0 ; i < fullBody->device_->numberDof() ; ++i)
+      weight[i] = 1.;
+  }
+
 
   // normalize weight array :
-  value_type moy =0;
+  /*value_type moy =0;
   int num_active = 0;
   for (size_type i = 0 ; i < weight.size() ; i++){
     if(mask[i]){
@@ -177,12 +163,13 @@ void CreatePosturalTaskConstraint(hpp::rbprm::RbPrmFullBodyPtr_t fullBody,core::
   for (size_type i = 0 ; i < weight.size() ; i++)
     weight[i] = weight[i]/moy;
 
+  */
 
-  /*std::ostringstream oss;
-  for (size_type i=0; i < mask.size (); ++i){
-    oss << mask [i] << ",";
+  std::ostringstream oss;
+  for (size_type i=0; i < weight.size (); ++i){
+    oss << weight [i] << ",";
   }
-  hppDout(notice,"mask = "<<oss.str());*/
+  //hppDout(notice,"weight postural task = "<<oss.str());
 
   //constraints::ConfigurationConstraintPtr_t postFunc = constraints::ConfigurationConstraint::create("Postural_Task",fullBody->device_,fullBody->referenceConfig(),weight,mask);
   constraints::ConfigurationConstraintPtr_t postFunc = constraints::ConfigurationConstraint::create("Postural_Task",fullBody->device_,fullBody->referenceConfig(),weight);

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -337,6 +337,7 @@ ProjectionReport projectEffector(hpp::core::ConfigProjectorPtr_t proj, const hpp
     }
 
     CreatePosturalTaskConstraint(body,proj);
+    proj->errorThreshold(1e-3);
     proj->lastIsOptional(true);
 
 

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -290,7 +290,6 @@ std::vector<bool> setRotationConstraints()
     {
         res.push_back(true);
     }
-    res[2] = false; // test
     return res;
 }
 
@@ -305,7 +304,7 @@ std::vector<bool> setTranslationConstraints()
 }
 ProjectionReport projectEffector(hpp::core::ConfigProjectorPtr_t proj, const hpp::rbprm::RbPrmFullBodyPtr_t& body, const std::string& limbId, const hpp::rbprm::RbPrmLimbPtr_t& limb,
                           core::CollisionValidationPtr_t validation, pinocchio::ConfigurationOut_t configuration,
-                          const fcl::Matrix3f& rotationTarget, const std::vector<bool> &rotationFilter, const fcl::Vec3f& positionTarget, const fcl::Vec3f& normal,
+                          const fcl::Matrix3f& rotationTarget, std::vector<bool> rotationFilter, const fcl::Vec3f& positionTarget, const fcl::Vec3f& normal,
                           const hpp::rbprm::State& current)
 {
     //hppDout(notice,"Project effector : ");
@@ -315,6 +314,8 @@ ProjectionReport projectEffector(hpp::core::ConfigProjectorPtr_t proj, const hpp
     rep.result_ = current;
     // Add constraints to resolve Ik
 
+    if(body->usePosturalTaskContactCreation())
+      rotationFilter[2] = false;
 
     const pinocchio::Frame effectorFrame = body->device_->getFrameByName(limb->effector_.name());
     pinocchio::JointPtr_t effectorJoint = effectorFrame.joint();
@@ -336,9 +337,11 @@ ProjectionReport projectEffector(hpp::core::ConfigProjectorPtr_t proj, const hpp
                                                                                       rotationFilter)));
     }
 
-    CreatePosturalTaskConstraint(body,proj);
-    proj->errorThreshold(1e-3);
-    proj->lastIsOptional(true);
+    if(body->usePosturalTaskContactCreation()){
+      CreatePosturalTaskConstraint(body,proj);
+      proj->errorThreshold(1e-3);
+      proj->lastIsOptional(true);
+    }
 
 
 #ifdef PROFILE

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -320,7 +320,7 @@ ProjectionReport projectEffector(hpp::core::ConfigProjectorPtr_t proj, const hpp
                           const fcl::Matrix3f& rotationTarget, const std::vector<bool> &rotationFilter, const fcl::Vec3f& positionTarget, const fcl::Vec3f& normal,
                           const hpp::rbprm::State& current)
 {
-    hppDout(notice,"Project effector : ");
+    //hppDout(notice,"Project effector : ");
     ProjectionReport rep;
     // Add constraints to resolve Ik
     rep.success_ = false;
@@ -401,18 +401,18 @@ ProjectionReport projectEffector(hpp::core::ConfigProjectorPtr_t proj, const hpp
 fcl::Transform3f computeProjectionMatrix(const hpp::rbprm::RbPrmFullBodyPtr_t& body, const hpp::rbprm::RbPrmLimbPtr_t& limb, const pinocchio::ConfigurationIn_t configuration,
                                          const fcl::Vec3f& normal, const fcl::Vec3f& position)
 {
-    hppDout(notice,"computeProjection matrice : normal = "<<normal.transpose());
+   // hppDout(notice,"computeProjection matrice : normal = "<<normal.transpose());
     body->device_->currentConfiguration(configuration);
     body->device_->computeForwardKinematics();
     // the normal is given by the normal of the contacted object
-    hppDout(notice,"effector rot : \n"<<limb->effector_.currentTransformation().rotation());
-    hppDout(notice,"limb normal : "<<limb->normal_.transpose());
+    //hppDout(notice,"effector rot : \n"<<limb->effector_.currentTransformation().rotation());
+    //hppDout(notice,"limb normal : "<<limb->normal_.transpose());
     const fcl::Vec3f z = limb->effector_.currentTransformation().rotation() * limb->normal_;
-    hppDout(notice,"z = "<<z.transpose());
+   // hppDout(notice,"z = "<<z.transpose());
     const fcl::Matrix3f alignRotation = tools::GetRotationMatrix(z,normal);
-    hppDout(notice,"alignRotation : \n"<<alignRotation);
+    //hppDout(notice,"alignRotation : \n"<<alignRotation);
     const fcl::Matrix3f rotation = alignRotation * limb->effector_.currentTransformation().rotation();
-    hppDout(notice,"rotation : \n"<<rotation);
+    //hppDout(notice,"rotation : \n"<<rotation);
     fcl::Vec3f posOffset = position - rotation * limb->offset_;
     posOffset = posOffset + normal * epsilon;
     return fcl::Transform3f(rotation,posOffset);
@@ -556,7 +556,9 @@ ProjectionReport projectSampleToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& b
     const fcl::Vec3f pEndEff = (rootT.act(report.sample_->effectorPosition_)); // compute absolute position (in world frame)
     fcl::Vec3f pos = pEndEff-(normal.dot(pEndEff-report.v1_))*normal; // orthogonal projection on the obstacle surface
     // make sure contact pos is actually on triangle, and take 1 cm margin ...
+    //hppDout(notice,"projectSampleToObstacle,                              pos = "<<pos.transpose());
     pos = closestPointInTriangle(pEndEff,report.v1_, report.v2_, report.v3_, 0.01);
+    //hppDout(notice,"projectSampleToObstacle, pos after projection in triangle = "<<pos.transpose());
     //hppDout(notice,"Effector position : "<<report.sample_->effectorPosition_);
     //hppDout(notice,"pEndEff = ["<<pEndEff[0]<<","<<pEndEff[1]<<","<<pEndEff[2]<<"]");
     //hppDout(notice,"pos = ["<<pos[0]<<","<<pos[1]<<","<<pos[2]<<"]");

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -290,6 +290,7 @@ std::vector<bool> setRotationConstraints()
     {
         res.push_back(true);
     }
+    res[2] = false; // test
     return res;
 }
 

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -335,6 +335,11 @@ ProjectionReport projectEffector(hpp::core::ConfigProjectorPtr_t proj, const hpp
                                                                                       rotation,
                                                                                       rotationFilter)));
     }
+
+    CreatePosturalTaskConstraint(body,proj);
+    proj->lastIsOptional(true);
+
+
 #ifdef PROFILE
     RbPrmProfiler& watch = getRbPrmProfiler();
     watch.start("ik");

--- a/src/rbprm-fullbody.cc
+++ b/src/rbprm-fullbody.cc
@@ -291,6 +291,7 @@ namespace hpp {
         , mu_(0.5)
         , reference_(device_->neutralConfiguration())
         , postureWeights_()
+        , usePosturalTaskContactCreation_(false)
         , effectorsTrajectoriesMaps_()
         , weakPtr_()
     {

--- a/src/sampling/heuristic.cc
+++ b/src/sampling/heuristic.cc
@@ -203,7 +203,7 @@ double fixedStepHeuristic(const sampling::Sample& sample,
 */
     if((pSample-pTarget).squaredNorm() > 1)
         hppDout(warning,"WARNING : In fixed step heuristic, norm is too high. You should change the hardcoded max value ");
-    return (1.-(pSample-pTarget).squaredNorm()) + 0.01*sample.staticValue_; // 1 - because it's an heuristic and not a cost
+    return (1.-(pSample-pTarget).squaredNorm()) + 0.1*sample.staticValue_; // 1 - because it's an heuristic and not a cost
 }
 
 

--- a/src/sampling/heuristic.cc
+++ b/src/sampling/heuristic.cc
@@ -189,18 +189,18 @@ double fixedStepHeuristic(const sampling::Sample& sample,
     tRootTarget.setTranslation(fcl::Vec3f(q_target.head<3>()));
     fcl::Quaternion3f quatRoot(q_target[6],q_target[3],q_target[4],q_target[5]);
     tRootTarget.setQuatRotation(quatRoot);
-    //hppDout(notice,"heuristic : tRootTarget = "<<tRootTarget.getRotation());
+   // hppDout(notice,"heuristic : tRootTarget = "<<tRootTarget.getRotation());
     //hppDout(notice,"heuristic : tRootTarget = "<<tRootTarget.getTranslation());
-   // hppDout(notice,"heuristic : limbRef     = "<<params.limbReferenceOffset_);
+    //hppDout(notice,"heuristic : limbRef     = "<<params.limbReferenceOffset_);
     fcl::Vec3f pTarget = (tRootTarget * params.limbReferenceOffset_).getTranslation();
     //hppDout(notice,"heuristic : pTarget = ["<<pTarget[0]<<","<<pTarget[1]<<","<<pTarget[2]<<"]");
     // FIXME : we could factorize all of the above and only do it once for each position of the CoM. But this require to know t_step in contact_generation::generate_contact ...
     fcl::Vec3f pSample = (params.tfWorldRoot_ * sample.effectorPosition_).getTranslation();
-/*    hppDout(notice,"Heuristic : norm     = "<<(pSample-pTarget).squaredNorm());
+  /*  hppDout(notice,"Heuristic : norm     = "<<(pSample-pTarget).squaredNorm());
     hppDout(notice,"Heuristic : 5 - norm = "<<5-(pSample-pTarget).squaredNorm());
     hppDout(notice,"Heuristic : static   = "<<sample.staticValue_);
     hppDout(notice,"Heuritic :           = "<<(5.-(pSample-pTarget).squaredNorm()) + sample.staticValue_);
- */
+*/
     if((pSample-pTarget).squaredNorm() > 1)
         hppDout(warning,"WARNING : In fixed step heuristic, norm is too high. You should change the hardcoded max value ");
     return (1.-(pSample-pTarget).squaredNorm()) + 1.*sample.staticValue_; // 1 - because it's an heuristic and not a cost

--- a/src/sampling/heuristic.cc
+++ b/src/sampling/heuristic.cc
@@ -203,7 +203,7 @@ double fixedStepHeuristic(const sampling::Sample& sample,
 */
     if((pSample-pTarget).squaredNorm() > 1)
         hppDout(warning,"WARNING : In fixed step heuristic, norm is too high. You should change the hardcoded max value ");
-    return (1.-(pSample-pTarget).squaredNorm()) + 1.*sample.staticValue_; // 1 - because it's an heuristic and not a cost
+    return (1.-(pSample-pTarget).squaredNorm()) + 0.01*sample.staticValue_; // 1 - because it's an heuristic and not a cost
 }
 
 

--- a/src/sampling/heuristic.cc
+++ b/src/sampling/heuristic.cc
@@ -222,6 +222,11 @@ double fixedStep06Heuristic(const sampling::Sample& sample,
     return fixedStepHeuristic(sample,direction,normal,params,0.6);
 }
 
+double fixedStep04Heuristic(const sampling::Sample& sample,
+                      const Eigen::Vector3d& direction, const Eigen::Vector3d& normal, const HeuristicParam & params){
+    return fixedStepHeuristic(sample,direction,normal,params,0.4);
+}
+
 
 double BackwardHeuristic(const sampling::Sample& sample,
                       const Eigen::Vector3d& direction, const Eigen::Vector3d& normal, const HeuristicParam & /*params*/)
@@ -275,6 +280,7 @@ HeuristicFactory::HeuristicFactory()
     heuristics_.insert(std::make_pair("fixedStep1", &fixedStep1Heuristic));
     heuristics_.insert(std::make_pair("fixedStep08", &fixedStep08Heuristic));
     heuristics_.insert(std::make_pair("fixedStep06", &fixedStep06Heuristic));
+    heuristics_.insert(std::make_pair("fixedStep04", &fixedStep04Heuristic));
 }
 
 HeuristicFactory::~HeuristicFactory(){}


### PR DESCRIPTION
## com-rrt / limb-rrt

* time-constraint-steering inherit of core::StraightSteering (required to use the progressive constrain projector)
* Temporarly disable com-constraint in com-rrt as it doesn't work with the constraints

## projection

* Update postural task to take the weight vector defined through the python API
* ProjectStateToObstacle : add optional parameter to lock all joints expect those of the moving limb (false by default to keep the previous behavior)

## contact generation

* Add a parameter in fullBody 'usePosturalTaskContactGeneration' : if True, when creating a new 6D contact the orientation of the effector along the contact normal is not constrained anymore, and we add a postural task to the config projector. **WIP** Only work when contact normal is along z axis for now. 
* Heuristic : greatly reduce the weight of the static value in 'fixedStep' heuristics
* Heuristic : add 'fixedStep04'
* Improve 'addGoalConfig' method called at the end of 'interpolate', now try all the combinatorial between the limbs

## planner

* fix tryConnectInitAndGoals  method (could fail to create the edge even though the trajectory was valid)
* Remove useless parameter in dynamicPlanner