### PR TITLE
projection : fix and add desired rotation

### DIFF
--- a/include/hpp/rbprm/projection/projection.hh
+++ b/include/hpp/rbprm/projection/projection.hh
@@ -74,10 +74,10 @@ ProjectionReport  HPP_RBPRM_DLLAPI setCollisionFree(hpp::rbprm::RbPrmFullBodyPtr
 
 
 ProjectionReport HPP_RBPRM_DLLAPI projectStateToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& body, const std::string& limbId, const hpp::rbprm::RbPrmLimbPtr_t& limb,
-                                                         const hpp::rbprm::State& current, const fcl::Vec3f &normal, const fcl::Vec3f &position,bool lockOtherJoints = false);
+                                                         const hpp::rbprm::State& current, const fcl::Vec3f &normal, const fcl::Vec3f &position,bool lockOtherJoints = false,const fcl::Matrix3f& rotation = fcl::Matrix3f::Zero());
 
 ProjectionReport HPP_RBPRM_DLLAPI projectStateToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& body, const std::string& limbId, const hpp::rbprm::RbPrmLimbPtr_t& limb,
-                                                         const hpp::rbprm::State& current, const fcl::Vec3f &normal, const fcl::Vec3f &position, core::CollisionValidationPtr_t validation, bool lockOtherJoints = false);
+                                                         const hpp::rbprm::State& current, const fcl::Vec3f &normal, const fcl::Vec3f &position, core::CollisionValidationPtr_t validation, bool lockOtherJoints = false,const fcl::Matrix3f& rotation = fcl::Matrix3f::Zero());
 
 ProjectionReport HPP_RBPRM_DLLAPI projectSampleToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& body,const std::string& limbId, const hpp::rbprm::RbPrmLimbPtr_t& limb,
                                                  const sampling::OctreeReport& report, core::CollisionValidationPtr_t validation,
@@ -89,7 +89,7 @@ ProjectionReport HPP_RBPRM_DLLAPI projectEffector(core::ConfigProjectorPtr_t pro
                                            const hpp::rbprm::State& current);
 
 fcl::Transform3f HPP_RBPRM_DLLAPI  computeProjectionMatrix(const hpp::rbprm::RbPrmFullBodyPtr_t& body, const hpp::rbprm::RbPrmLimbPtr_t& limb, const pinocchio::ConfigurationIn_t configuration,
-                                         const fcl::Vec3f& normal, const fcl::Vec3f& position);
+                                         const fcl::Vec3f& normal, const fcl::Vec3f& position,const fcl::Matrix3f& rotation = fcl::Matrix3f::Zero());
 
     } // namespace projection
   } // namespace rbprm

--- a/src/contact_generation/contact_generation.cc
+++ b/src/contact_generation/contact_generation.cc
@@ -459,7 +459,7 @@ hpp::rbprm::State findValidCandidate(const ContactGenHelper &contactGenHelper, c
                         RbPrmLimbPtr_t limb, core::CollisionValidationPtr_t validation, bool& found_sample,bool& found_stable,
                                      bool& unstableContact, const sampling::HeuristicParam & params, const sampling::heuristic evaluate = 0)
 {
-    State current = contactGenHelper.workingState_;
+    State current(contactGenHelper.workingState_);
     current.stable = false;
     State intermediateState(current); // state before new contact creation
     State previous(contactGenHelper.previousState_); // previous state, before contact break
@@ -605,6 +605,15 @@ hpp::rbprm::State findValidCandidate(const ContactGenHelper &contactGenHelper, c
     fout<<"evaluatedCandidates "<<evaluatedCandidates<<std::endl;
     fout.close();
 */
+    if(contactGenHelper.fullBody_->usePosturalTaskContactCreation() && !found_sample){
+      // as the contact generator is not complete when usePosturalTaskContactCreation==True, if it fail we retry without this option
+      contactGenHelper.fullBody_->usePosturalTaskContactCreation(false);
+      current =findValidCandidate(contactGenHelper,limbId,
+                                  limb, validation,found_sample,found_stable,
+                                  unstableContact,params,evaluate);
+      contactGenHelper.fullBody_->usePosturalTaskContactCreation(true);
+
+    }
 
     return current;
 }

--- a/src/planner/rbprm-node.cc
+++ b/src/planner/rbprm-node.cc
@@ -340,7 +340,7 @@ void RbprmNode::chooseBestContactSurface(ValidationReportPtr_t report, pinocchio
           geom::Point normal,proj;
           double minDistance = std::numeric_limits<double>::max();
           double distance;
-          CollisionValidationReportPtr_t bestReport;
+          CollisionValidationReportPtr_t bestReport(romReports->collisionReports.front());
           bool successInter;
           geom::T_Point intersection;
           hppDout(notice,"Number of possible surfaces for rom : "<<romReports->collisionReports.size());

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -339,20 +339,21 @@ ProjectionReport projectEffector(hpp::core::ConfigProjectorPtr_t proj, const hpp
     const pinocchio::Frame effectorFrame = body->device_->getFrameByName(limb->effector_.name());
     pinocchio::JointPtr_t effectorJoint = effectorFrame.joint();
     Transform3f localFrame(1), globalFrame(1);
+    localFrame = effectorFrame.pinocchio().placement * localFrame;
     globalFrame.translation(positionTarget);
     proj->add(constraints::Implicit::create (constraints::Position::create("",body->device_,
                                                                                effectorJoint,
-                                                                               effectorFrame.pinocchio().placement * localFrame,
+                                                                               localFrame,
                                                                                globalFrame,
                                                                                setTranslationConstraints())));
     if(limb->contactType_ == hpp::rbprm::_6_DOF)
     {
-        Transform3f rotation(1);
-        //rotation.rotation(rotationTarget);
-        rotation.rotation(rotationTarget * effectorFrame.pinocchio().placement.rotation().transpose());
+        //localFrame.rotation(effectorFrame.pinocchio().placement.rotation() * rotationTarget.transpose());
+        globalFrame.rotation(rotationTarget);
         proj->add(constraints::Implicit::create (constraints::Orientation::create("",body->device_,
                                                                                       effectorJoint,
-                                                                                      rotation,
+                                                                                      localFrame,
+                                                                                      globalFrame,
                                                                                       rotationFilter)));
     }
 

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -332,7 +332,7 @@ ProjectionReport projectEffector(hpp::core::ConfigProjectorPtr_t proj, const hpp
     rep.success_ = false;
     rep.result_ = current;
     // Add constraints to resolve Ik
-
+    hppDout(notice,"Project effector to position : "<<positionTarget);
     if(body->usePosturalTaskContactCreation())
       rotationFilter[2] = false;
 
@@ -464,6 +464,7 @@ double clamp( const double& val, const double& lo, const double& hi)
 
 fcl::Vec3f closestPointInTriangle(const fcl::Vec3f& sourcePosition, const fcl::Vec3f& t0, const fcl::Vec3f& t1, const fcl::Vec3f& t2, const double epsilon =0. )
 {
+    hppDout(notice,"closestPointInTriangle : t0 = "<<t0.transpose()<<" ; t1 = "<<t1.transpose()<<" ; t2 = "<<t2.transpose());
     const fcl::Vec3f edge0 = t1 - t0;
     const fcl::Vec3f edge1 = t2 - t0;
     const fcl::Vec3f v0 = t0 - sourcePosition;
@@ -576,9 +577,12 @@ ProjectionReport projectSampleToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& b
     //compute the orthogonal projection of the end effector on the plan :
     const fcl::Vec3f pEndEff = (rootT.act(report.sample_->effectorPosition_)); // compute absolute position (in world frame)
     fcl::Vec3f pos = pEndEff-(normal.dot(pEndEff-report.v1_))*normal; // orthogonal projection on the obstacle surface
+    hppDout(notice,"project sample to obstacle : orthogonal projection = "<<pos);
     // make sure contact pos is actually on triangle, and take 1 cm margin ...
     //hppDout(notice,"projectSampleToObstacle,                              pos = "<<pos.transpose());
     pos = closestPointInTriangle(pEndEff,report.v1_, report.v2_, report.v3_, 0.01);
+    hppDout(notice,"project sample to obstacle : after project inside triangle = "<<pos);
+
     //hppDout(notice,"projectSampleToObstacle, pos after projection in triangle = "<<pos.transpose());
     //hppDout(notice,"Effector position : "<<report.sample_->effectorPosition_);
     //hppDout(notice,"pEndEff = ["<<pEndEff[0]<<","<<pEndEff[1]<<","<<pEndEff[2]<<"]");

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -569,7 +569,7 @@ ProjectionReport projectSampleToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& b
     sampling::Load(*report.sample_, configuration);
     fcl::Vec3f normal = report.normal_;
     normal.normalize();
-    value_type epsilon = 0.01;
+    //value_type epsilon = 0.01;
    // hppDout(notice,"contact normal = "<<normal);
     Transform3f rootT;
     if (body->GetLimb(limbId)->limb_->parentJoint())
@@ -584,8 +584,8 @@ ProjectionReport projectSampleToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& b
     //hppDout(notice,"projectSampleToObstacle,                              pos = "<<pos.transpose());
     pos = closestPointInTriangle(pEndEff,report.v1_, report.v2_, report.v3_, 0.);
     hppDout(notice,"project sample to obstacle : after project inside triangle = "<<pos);
-    pos += normal*epsilon;
-    hppDout(notice,"project sample to obstacle : after epsilon = "<<pos);
+    //pos += normal*epsilon;
+    //hppDout(notice,"project sample to obstacle : after epsilon = "<<pos);
     //hppDout(notice,"projectSampleToObstacle, pos after projection in triangle = "<<pos.transpose());
     //hppDout(notice,"Effector position : "<<report.sample_->effectorPosition_);
     //hppDout(notice,"pEndEff = ["<<pEndEff[0]<<","<<pEndEff[1]<<","<<pEndEff[2]<<"]");

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -568,6 +568,7 @@ ProjectionReport projectSampleToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& b
     sampling::Load(*report.sample_, configuration);
     fcl::Vec3f normal = report.normal_;
     normal.normalize();
+    value_type epsilon = 0.01;
    // hppDout(notice,"contact normal = "<<normal);
     Transform3f rootT;
     if (body->GetLimb(limbId)->limb_->parentJoint())
@@ -580,9 +581,10 @@ ProjectionReport projectSampleToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& b
     hppDout(notice,"project sample to obstacle : orthogonal projection = "<<pos);
     // make sure contact pos is actually on triangle, and take 1 cm margin ...
     //hppDout(notice,"projectSampleToObstacle,                              pos = "<<pos.transpose());
-    pos = closestPointInTriangle(pEndEff,report.v1_, report.v2_, report.v3_, 0.01);
+    pos = closestPointInTriangle(pEndEff,report.v1_, report.v2_, report.v3_, 0.);
     hppDout(notice,"project sample to obstacle : after project inside triangle = "<<pos);
-
+    pos += normal*epsilon;
+    hppDout(notice,"project sample to obstacle : after epsilon = "<<pos);
     //hppDout(notice,"projectSampleToObstacle, pos after projection in triangle = "<<pos.transpose());
     //hppDout(notice,"Effector position : "<<report.sample_->effectorPosition_);
     //hppDout(notice,"pEndEff = ["<<pEndEff[0]<<","<<pEndEff[1]<<","<<pEndEff[2]<<"]");

--- a/src/rbprm-shooter.cc
+++ b/src/rbprm-shooter.cc
@@ -287,6 +287,8 @@ namespace
     : shootLimit_(shootLimit)
     , displacementLimit_(displacementLimit)
     , filter_(filter)
+    , weights_()
+    , triangles_()
     , robot_ (robot)
     , validator_(rbprm::RbPrmValidation::create(robot_, filter, affFilters,
                                                 affordances, geometries))
@@ -317,19 +319,22 @@ namespace
                 tri.p2 = colObj->getRotation() * model->vertices[fcltri[1]] + colObj->getTranslation();
                 tri.p3 = colObj->getRotation() * model->vertices[fcltri[2]] + colObj->getTranslation();
                 double weight = TriangleArea(tri);
+                hppDout(notice,"Area of triangle = "<<weight);
                 sum += weight;
                 weights_.push_back(weight);
                 fcl::Vec3f normal = (tri.p2 - tri.p1).cross(tri.p3 - tri.p1);
                 normal.normalize();
                 triangles_.push_back(std::make_pair(normal,tri));
             }
-            double previousWeight = 0;
-            for(std::vector<double>::iterator wit = weights_.begin();
-                wit != weights_.end(); ++wit)
-            {
-                previousWeight += (*wit) / sum;
-                (*wit) = previousWeight;
-            }
+        }
+        double previousWeight = 0;
+        hppDout(notice,"Sum of all areas of triangles : "<<sum);
+        for(std::vector<double>::iterator wit = weights_.begin();
+            wit != weights_.end(); ++wit)
+        {
+            previousWeight += (*wit) / sum;
+            (*wit) = previousWeight;
+            hppDout(notice,"current weight = "<<previousWeight);
         }
         hppDout(notice,"number of triangle for the shooter : "<<triangles_.size());
     }

--- a/src/sampling/heuristic.cc
+++ b/src/sampling/heuristic.cc
@@ -175,11 +175,29 @@ double DynamicWalkHeuristic(const sampling::Sample& sample,
 }
 
 
+double StaticHeuristic(const sampling::Sample& sample,
+                      const Eigen::Vector3d& /*direction*/, const Eigen::Vector3d& /*normal*/, const HeuristicParam & /*params*/)
+{
+    /*hppDout(info,"sample : ");
+    hppDout(info,"sample : "<<&sample);
+    hppDout(info,"id = "<<sample.id_);
+    hppDout(info,"length = "<<sample.length_);
+    hppDout(info,"startRank = "<<sample.startRank_);
+    hppDout(info,"effectorPosition = "<<sample.effectorPosition_);
+    hppDout(info,"configuration = "<<sample.configuration_);
+    hppDout(info,"staticValue = "<<sample.staticValue_);
+    */
+    return sample.staticValue_;
+
+}
+
+
+
 double fixedStepHeuristic(const sampling::Sample& sample,
                       const Eigen::Vector3d& direction, const Eigen::Vector3d& normal, const HeuristicParam & params,const double t_step){
     if(! params.comPath_){
-        hppDout(notice,"In heuristic : comPath was not provided, use default heuristic");
-        return DynamicWalkHeuristic(sample,direction,normal,params);
+        hppDout(notice,"In heuristic : comPath was not provided, use only current analysis score");
+        return StaticHeuristic(sample,direction,normal,params);
     }
     //hppDout(notice,"FixedStep heuristic : comPath exist");
     bool success;
@@ -232,22 +250,6 @@ double BackwardHeuristic(const sampling::Sample& sample,
                       const Eigen::Vector3d& direction, const Eigen::Vector3d& normal, const HeuristicParam & /*params*/)
 {
     return sample.staticValue_ * 10000 * Eigen::Vector3d::UnitZ().dot(normal) - 100  * sample.effectorPosition_.dot(fcl::Vec3f(direction(0),direction(1),direction(2))) + ((double)rand()) / ((double)(RAND_MAX));
-}
-
-double StaticHeuristic(const sampling::Sample& sample,
-                      const Eigen::Vector3d& /*direction*/, const Eigen::Vector3d& /*normal*/, const HeuristicParam & /*params*/)
-{
-    /*hppDout(info,"sample : ");
-    hppDout(info,"sample : "<<&sample);
-    hppDout(info,"id = "<<sample.id_);
-    hppDout(info,"length = "<<sample.length_);
-    hppDout(info,"startRank = "<<sample.startRank_);
-    hppDout(info,"effectorPosition = "<<sample.effectorPosition_);
-    hppDout(info,"configuration = "<<sample.configuration_);
-    hppDout(info,"staticValue = "<<sample.staticValue_);
-    */
-    return sample.staticValue_;
-
 }
 
 


### PR DESCRIPTION
## changes in projection : 
* projectStateToObstacle : now take optional argument `rotation` to define a desired rotation of the end effector. If this rotation is provided, the `normal` argument is ignored (todo : at least check that the `rotation` and the `normal` values are consistent, and maybe always rotate to match the normal if not).
* when `usePosturalTaskContactCreation = true` correctly allow the rotation to move along the contact normal, and not along the z axis.

## contact generation : 
* if `usePosturalTaskContactCreation = true` and the projection fail, try again without
* fixedStep heuristic : if called without information about the future root's path, use the static heuristic. 
* projection : `closestPointInTriangle` remove the hardcoded `epsilon` used to move in the direction of (orthogonalProjection -> projection inside the triangle). This change have been made because when the orthogonal projection is already inside the triangle, the numerical approximations may lead to a direction which go inside the obstacle.

## Bugs fix : 
* rbprm shooter : fix error in computation of the weights for each triangles
* `RbprmNode::chooseBestContactSurface` fix a segfault where `bestReport` could be unitialized when the computation of the intersection fail. (FIXME : I still don't understand why `computeIntersectionSurface` can fail)