### PR TITLE
Fix Analysis and reachability

### DIFF
--- a/src/sampling/analysis.cc
+++ b/src/sampling/analysis.cc
@@ -194,7 +194,7 @@ namespace
             val= (val - lb) * (ub - val) / ((ub - lb) * (ub - lb));
             currentDistance = std::min(currentDistance, val);
         }
-        if(lastJoint == currentJoint->name())
+        if(lastJoint == currentJoint->name() || currentJoint->numberChildJoints() == 0)
             return;
         else return distanceRec(conf, lastJoint, currentJoint->childJoint(0),currentDistance);
     }

--- a/src/sampling/analysis.cc
+++ b/src/sampling/analysis.cc
@@ -290,8 +290,8 @@ namespace
         weights = computeWeightsFromAxis(limb,device);
         //hppDout(notice,"Analysis : posture weight not defined in fullbody, computed weight : "<<hpp::pinocchio::displayConfig(weights));
       }
-
-      hpp::pinocchio::difference (device, conf, fullBody->referenceConfig(), diff);
+      const int nq = device->configSize() - device->extraConfigSpace().dimension();
+      hpp::pinocchio::difference (device, conf.segment(0,nq), fullBody->referenceConfig().segment(0,nq), diff);
      // hppDout(notice,"Reference config in analysis : "<<pinocchio::displayConfig(fullBody->referenceConfig()));
       // the difference vector depend on the index in the velocity vector, not in the configuration
       // we only sum for the index of the current limb


### PR DESCRIPTION
* `ReferenceConfiguration` was not working when using extraConfigs, but an error only appear since the pinocchio update that added explicit checks of the dimensions of the inputs of the `difference` method.

* `jointLimitsDistance` was not working when using frame name for defining the limb's effector instead of joint name. The current fix do not fix the issue if the effector name is the name of a frame which is not the attached to the last joint of the kinematic sub-tree of the limb ... 

* In reachability, correctly check the success of the double description method and the computation of the stability constraints. There was a silent failure in Release and a failling assert in Eigen in Debug in the case where `getPolytopeInequalities` did not converge. 