### PR TITLE
Contact Generation: only sort the sample DB once

### DIFF
--- a/include/hpp/rbprm/projection/projection.hh
+++ b/include/hpp/rbprm/projection/projection.hh
@@ -68,9 +68,8 @@ ProjectionReport HPP_RBPRM_DLLAPI projectToRootConfiguration(hpp::rbprm::RbPrmFu
 /// Project a configuration such that a given limb configuration is collision free
 /// \param fullBody target Robot
 /// \param limb considered limb
-/// \param sort if true, the samples are first sorted with thier static value, such that the returned collision free configuration is the one with the best value
 /// \return projection report containing the state projected
-ProjectionReport  HPP_RBPRM_DLLAPI setCollisionFree(hpp::rbprm::RbPrmFullBodyPtr_t fullBody, const core::CollisionValidationPtr_t &validation, const std::string& limb, const hpp::rbprm::State& currentState,bool sort = false);
+ProjectionReport  HPP_RBPRM_DLLAPI setCollisionFree(hpp::rbprm::RbPrmFullBodyPtr_t fullBody, const core::CollisionValidationPtr_t &validation, const std::string& limb, const hpp::rbprm::State& currentState);
 
 
 ProjectionReport HPP_RBPRM_DLLAPI projectStateToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& body, const std::string& limbId, const hpp::rbprm::RbPrmLimbPtr_t& limb,

--- a/include/hpp/rbprm/projection/projection.hh
+++ b/include/hpp/rbprm/projection/projection.hh
@@ -70,7 +70,7 @@ ProjectionReport HPP_RBPRM_DLLAPI projectToRootConfiguration(hpp::rbprm::RbPrmFu
 /// \param limb considered limb
 /// \param sort if true, the samples are first sorted with thier static value, such that the returned collision free configuration is the one with the best value
 /// \return projection report containing the state projected
-ProjectionReport  HPP_RBPRM_DLLAPI setCollisionFree(hpp::rbprm::RbPrmFullBodyPtr_t fullBody, const core::CollisionValidationPtr_t &validation, const std::string& limb, const hpp::rbprm::State& currentState,bool sort = true);
+ProjectionReport  HPP_RBPRM_DLLAPI setCollisionFree(hpp::rbprm::RbPrmFullBodyPtr_t fullBody, const core::CollisionValidationPtr_t &validation, const std::string& limb, const hpp::rbprm::State& currentState,bool sort = false);
 
 
 ProjectionReport HPP_RBPRM_DLLAPI projectStateToObstacle(const hpp::rbprm::RbPrmFullBodyPtr_t& body, const std::string& limbId, const hpp::rbprm::RbPrmLimbPtr_t& limb,

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -267,7 +267,7 @@ ProjectionReport projectToRootConfiguration(hpp::rbprm::RbPrmFullBodyPtr_t fullB
 }
 
 ProjectionReport setCollisionFree(hpp::rbprm::RbPrmFullBodyPtr_t fullBody, const core::CollisionValidationPtr_t& validation ,
-                                  const std::string& limbName,const hpp::rbprm::State& currentState,bool sort)
+                                  const std::string& limbName,const hpp::rbprm::State& currentState)
 {
     ProjectionReport res;
     res.result_ = currentState;
@@ -283,10 +283,6 @@ ProjectionReport setCollisionFree(hpp::rbprm::RbPrmFullBodyPtr_t fullBody, const
 
     RbPrmLimbPtr_t limb = fullBody->GetLimb(limbName);
     sampling::T_Sample& samples = limb->sampleContainer_.samples_;
-    if(sort){
-        sampling::sample_greater sortAlgo;
-        std::sort(samples.begin(),samples.end(),sortAlgo);
-    }
     for(sampling::SampleVector_t::const_iterator cit = samples.begin();cit != samples.end(); ++cit)
     {
         sampling::Load(*cit, configuration);

--- a/src/projection/projection.cc
+++ b/src/projection/projection.cc
@@ -282,7 +282,7 @@ ProjectionReport setCollisionFree(hpp::rbprm::RbPrmFullBodyPtr_t fullBody, const
     }
 
     RbPrmLimbPtr_t limb = fullBody->GetLimb(limbName);
-    sampling::T_Sample samples(limb->sampleContainer_.samples_);
+    sampling::T_Sample& samples = limb->sampleContainer_.samples_;
     if(sort){
         sampling::sample_greater sortAlgo;
         std::sort(samples.begin(),samples.end(),sortAlgo);

--- a/src/rbprm-fullbody.cc
+++ b/src/rbprm-fullbody.cc
@@ -119,9 +119,6 @@ namespace hpp {
             group.push_back(id);
             limbGroups_.insert(std::make_pair(name, group));
         }
-        sampling::T_Sample& samples = limb->sampleContainer_.samples_;
-        sampling::sample_greater sortAlgo;
-        std::sort(samples.begin(),samples.end(),sortAlgo);
     }
 
     std::map<std::string, const sampling::heuristic>::const_iterator checkLimbData(const std::string& id, const rbprm::T_Limb& limbs, const rbprm::sampling::HeuristicFactory& factory, const std::string& heuristicName)

--- a/src/rbprm-fullbody.cc
+++ b/src/rbprm-fullbody.cc
@@ -119,6 +119,9 @@ namespace hpp {
             group.push_back(id);
             limbGroups_.insert(std::make_pair(name, group));
         }
+        sampling::T_Sample& samples = limb->sampleContainer_.samples_;
+        sampling::sample_greater sortAlgo;
+        std::sort(samples.begin(),samples.end(),sortAlgo);
     }
 
     std::map<std::string, const sampling::heuristic>::const_iterator checkLimbData(const std::string& id, const rbprm::T_Limb& limbs, const rbprm::sampling::HeuristicFactory& factory, const std::string& heuristicName)


### PR DESCRIPTION
Instead of sorting the `limb->sampleContainer_` at each call to `setCollisionFree`, sort it when the Limb is first created. 

The sorting comparator used here only care about the `staticValue_` of each sample, which is constant once the database have been created so there is no need to sort it at each iteration. 