### PR TITLE
[Reachability] set TryQuasiStatic to the same value as staticStability

### DIFF
--- a/include/hpp/rbprm/contact_generation/reachability.hh
+++ b/include/hpp/rbprm/contact_generation/reachability.hh
@@ -102,7 +102,7 @@ std::pair<MatrixXX, VectorX> computeConstraintsForState(const RbPrmFullBodyPtr_t
  */
 Result isReachable(const RbPrmFullBodyPtr_t& fullbody,State &previous, State& next,const fcl::Vec3f& acc = fcl::Vec3f::Zero(), bool useIntermediateState = false);
 
-Result isReachableDynamic(const RbPrmFullBodyPtr_t& fullbody, State &previous, State& next, bool tryQuasiStatic = false, std::vector<double> timings = std::vector<double>(), int numPointsPerPhases = 0);
+Result isReachableDynamic(const RbPrmFullBodyPtr_t& fullbody, State &previous, State& next, bool tryQuasiStatic = true, std::vector<double> timings = std::vector<double>(), int numPointsPerPhases = 0);
 
 
 

--- a/src/contact_generation/contact_generation.cc
+++ b/src/contact_generation/contact_generation.cc
@@ -63,7 +63,7 @@ ContactGenHelper::ContactGenHelper(RbPrmFullBodyPtr_t fb, const State& ps, pinoc
 , testReachability_(true)
 , maximiseContacts_(true)
 , accept_unreachable_(false)
-, tryQuasiStatic_(true)
+, tryQuasiStatic_(fb->staticStability())
 , reachabilityPointPerPhases_(0)
 {
     workingState_.configuration_ = configuration;

--- a/src/contact_generation/contact_generation.cc
+++ b/src/contact_generation/contact_generation.cc
@@ -63,7 +63,7 @@ ContactGenHelper::ContactGenHelper(RbPrmFullBodyPtr_t fb, const State& ps, pinoc
 , testReachability_(true)
 , maximiseContacts_(true)
 , accept_unreachable_(false)
-, tryQuasiStatic_(false)
+, tryQuasiStatic_(true)
 , reachabilityPointPerPhases_(0)
 {
     workingState_.configuration_ = configuration;

--- a/src/contact_generation/reachability.cc
+++ b/src/contact_generation/reachability.cc
@@ -529,7 +529,7 @@ Result isReachableDynamic(const RbPrmFullBodyPtr_t& fullbody, State &previous, S
             wps.push_back(com_previous);
             wps.push_back(quasiStaticResult.x);
             wps.push_back(com_next);
-            bezier_Ptr bezierCurve=bezier_Ptr(new bezier_t(wps.begin(),wps.end(),1.));
+            bezier_Ptr bezierCurve=bezier_Ptr(new bezier_t(wps.begin(), wps.end()));
             quasiStaticResult.path_ = BezierPath::create(fullbody->device_,bezierCurve,previous.configuration_,next.configuration_, core::interval_t(0.,1));
             quasiStaticSucces = true;
             #if !STAT_TIMINGS


### PR DESCRIPTION
If `staticStability` is True, then the acceleration from the guide is ignored during contact planning. 

if  `tryQuasiStatic` is True, when checking the reachability during the contact planning it start by calling 2-PAC and only call CROC if 2-PAC fail.

`tryQuasiStatic` was always set to False by default, with no python API to change this and only put to True in a few place in the code. As 2-PAC is a lot faster than CROC I do not see a reason where we want it to False when checking the reachability with a null init/final acceleration. 

It make sense when we want to compute and retrieve the CoM trajectory from CROC between two states, but there is already a specific API for this that correctly set this value to False.