### PR TITLE
fix boost bind placeholders

### DIFF
--- a/tests/tools-obstacle.hh
+++ b/tests/tools-obstacle.hh
@@ -38,6 +38,13 @@
 #include <hpp/rbprm/planner/oriented-path-optimizer.hh>
 #include <hpp/rbprm/dynamic/dynamic-path-validation.hh>
 
+#if BOOST_VERSION / 100 % 1000 >= 60
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
+#else
+#include <boost/bind.hpp>
+#endif
+
 using namespace hpp;
 using namespace hpp::core;
 


### PR DESCRIPTION
otherwise, with a recent Boost:

/usr/include/boost/bind.hpp:36:1: note: « #pragma message: The practice
of declaring the Bind placeholders (_1, _2, ...) in the global namespace
is deprecated. Please use <boost/bind/bind.hpp> + using namespace
boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain
the current behavior. »